### PR TITLE
[codex] Harden WebGPU lab startup

### DIFF
--- a/src/routes/BeautyMaterialLabRoute.tsx
+++ b/src/routes/BeautyMaterialLabRoute.tsx
@@ -13,6 +13,7 @@ import { createBeautyLabMaterialFactory, SEGMENT_COLORS } from '../features/beau
 import { BeautyBust, SceneGrade, StudioLightRig } from '../features/beauty-lab/scene';
 import { DEBUG_SEGMENTS, type BeautyMaterialMode, type DebugSegment, type FacecapConditioningData } from '../features/beauty-lab/types';
 import { createSkinUniforms } from '../features/beauty-lab/uniforms';
+import { probeWebGPUSession, type WebGPUSessionProbeResult } from '../utils/webgpuSession';
 
 function RouteShell({
   children,
@@ -106,6 +107,21 @@ function LoadingState({ message }: { message: string }) {
   );
 }
 
+function WebGPUFailureState({ result }: { result: WebGPUSessionProbeResult }) {
+  return (
+    <div className="flex h-full items-center justify-center px-6">
+      <div className="max-w-xl rounded-3xl border border-amber-300/20 bg-amber-100/10 px-6 py-5 text-amber-50 backdrop-blur-sm">
+        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-amber-300">WebGPU lab unavailable</p>
+        <h2 className="mt-3 text-xl font-semibold">This browser GPU session is not healthy enough to start the lab.</h2>
+        <p className="mt-3 text-sm leading-6 text-amber-50/85">{result.message}</p>
+        <p className="mt-3 text-xs leading-5 text-amber-50/60">
+          The main presentation route remains safe to use. This guard prevents the WebGPU lab from creating a renderer in a stale or unsupported page session.
+        </p>
+      </div>
+    </div>
+  );
+}
+
 export default function BeautyMaterialLabRoute() {
   const { showStats, exposure } = useControls('Lab', {
     showStats: false,
@@ -137,9 +153,14 @@ export default function BeautyMaterialLabRoute() {
   const [loadingError, setLoadingError] = React.useState<string | null>(null);
   const [mode, setMode] = React.useState<BeautyMaterialMode>('beauty');
   const [debugSegment, setDebugSegment] = React.useState<DebugSegment>('all-regions');
+  const [webgpuProbe, setWebgpuProbe] = React.useState<WebGPUSessionProbeResult | null>(null);
 
   useEffect(() => {
     let cancelled = false;
+
+    probeWebGPUSession().then((result) => {
+      if (!cancelled) setWebgpuProbe(result);
+    });
 
     loadFacecapConditioning()
       .then((data) => {
@@ -206,6 +227,11 @@ export default function BeautyMaterialLabRoute() {
     shadows: true,
     gl: (async (defaults: Record<string, unknown>) => {
       const canvas = defaults.canvas as HTMLCanvasElement;
+      const result = await probeWebGPUSession({ canvas });
+      if (!result.ok) {
+        setWebgpuProbe(result);
+        throw new Error(result.message);
+      }
       const renderer = new THREE_WEBGPU.WebGPURenderer({ canvas, antialias: true, forceWebGL: false });
       await renderer.init();
       return renderer;
@@ -216,7 +242,11 @@ export default function BeautyMaterialLabRoute() {
     <RouteShell mode={mode} setMode={setMode} debugSegment={debugSegment} setDebugSegment={setDebugSegment}>
       <Leva hidden={mode === 'debug'} collapsed={false} />
 
-      {!conditioningData || !materialFactory ? (
+      {!webgpuProbe ? (
+        <LoadingState message="Checking the WebGPU adapter and canvas context before starting the lab." />
+      ) : !webgpuProbe.ok ? (
+        <WebGPUFailureState result={webgpuProbe} />
+      ) : !conditioningData || !materialFactory ? (
         <LoadingState message={loadingError ? `Conditioning payload failed to load: ${loadingError}` : 'Loading the conditioned face payload and detail atlases for the beauty lab.'} />
       ) : (
         <>

--- a/src/routes/MaterialParityRoute.tsx
+++ b/src/routes/MaterialParityRoute.tsx
@@ -1,7 +1,7 @@
 import { AdaptiveDpr, OrbitControls, Stats, useGLTF } from '@react-three/drei';
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import { useControls } from 'leva';
-import { Suspense, useEffect, useMemo } from 'react';
+import { Suspense, useEffect, useMemo, useState } from 'react';
 import * as THREE from 'three';
 import { clone as cloneSkeleton } from 'three/examples/jsm/utils/SkeletonUtils.js';
 import { KTX2Loader } from 'three-stdlib';
@@ -9,6 +9,7 @@ import * as THREE_WEBGPU from 'three/webgpu';
 import AppNav from '../components/AppNav';
 import CanvasErrorBoundary from '../components/CanvasErrorBoundary';
 import CubemapEnvironment from '../components/CubemapEnvironment';
+import { probeWebGPUSession, type WebGPUSessionProbeResult } from '../utils/webgpuSession';
 
 const FACECAP_URL = 'https://raw.githubusercontent.com/mrdoob/three.js/master/examples/models/gltf/facecap.glb';
 
@@ -94,18 +95,49 @@ function WebGLViewport({ exposure, showStats }: { exposure: number; showStats: b
   );
 }
 
-function WebGPUViewport({ exposure, showStats }: { exposure: number; showStats: boolean }) {
+function WebGPUStatusPanel({ result }: { result: WebGPUSessionProbeResult | null }) {
+  const message = result?.message ?? 'Checking the WebGPU adapter and canvas context before starting the comparison viewport.';
+
+  return (
+    <div className="flex h-full items-center justify-center p-6">
+      <div className="max-w-md rounded-3xl border border-amber-300/20 bg-amber-100/10 p-6 text-amber-50 backdrop-blur">
+        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-amber-300">
+          {result ? 'WebGPU unavailable' : 'WebGPU preflight'}
+        </p>
+        <h2 className="mt-3 text-xl font-semibold">
+          {result ? 'The WebGPU side cannot start in this browser session.' : 'Checking WebGPU session health.'}
+        </h2>
+        <p className="mt-3 text-sm leading-6 text-amber-50/85">{message}</p>
+      </div>
+    </div>
+  );
+}
+
+function WebGPUViewport({
+  exposure,
+  showStats,
+  onProbeFailure,
+}: {
+  exposure: number;
+  showStats: boolean;
+  onProbeFailure: (result: WebGPUSessionProbeResult) => void;
+}) {
   return (
     <Canvas
       camera={{ position: [0, 0.05, 7.4], fov: 40 }}
       dpr={[1, 1.5]}
       shadows
       gl={async (props) => {
+        const result = await probeWebGPUSession({ canvas: props.canvas as HTMLCanvasElement });
+        if (!result.ok) {
+          onProbeFailure(result);
+          throw new Error(result.message);
+        }
+
         const renderer = new THREE_WEBGPU.WebGPURenderer({
           canvas: props.canvas as HTMLCanvasElement,
           antialias: false,
           alpha: false,
-          powerPreference: 'high-performance',
         } as ConstructorParameters<typeof THREE_WEBGPU.WebGPURenderer>[0]);
         await renderer.init();
         return renderer;
@@ -124,11 +156,21 @@ function WebGPUViewport({ exposure, showStats }: { exposure: number; showStats: 
 }
 
 export default function MaterialParityRoute() {
-  const supportsWebGPU = typeof navigator !== 'undefined' && 'gpu' in navigator;
   const { exposure, showStats } = useControls('Parity Lab', {
     exposure: { value: 1.2, min: 0.5, max: 3, step: 0.01 },
     showStats: false,
   });
+  const [webgpuProbe, setWebgpuProbe] = useState<WebGPUSessionProbeResult | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    probeWebGPUSession().then((result) => {
+      if (!cancelled) setWebgpuProbe(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   return (
     <div className="relative h-screen w-full overflow-hidden bg-stone-950 text-stone-100">
@@ -157,17 +199,12 @@ export default function MaterialParityRoute() {
         </CanvasErrorBoundary>
 
         <CanvasErrorBoundary>
-          {supportsWebGPU ? (
-            <WebGPUViewport exposure={exposure} showStats={showStats} />
+          {!webgpuProbe ? (
+            <WebGPUStatusPanel result={null} />
+          ) : webgpuProbe.ok ? (
+            <WebGPUViewport exposure={exposure} showStats={showStats} onProbeFailure={setWebgpuProbe} />
           ) : (
-            <div className="flex h-full items-center justify-center p-6">
-              <div className="max-w-md rounded-3xl border border-amber-300/20 bg-amber-100/10 p-6 text-amber-50 backdrop-blur">
-                <h2 className="text-xl font-semibold">WebGPU is not available in this browser.</h2>
-                <p className="mt-3 text-sm leading-6 text-amber-50/85">
-                  Open this route in a Chromium-based browser with WebGPU enabled to compare the untouched source materials directly.
-                </p>
-              </div>
-            </div>
+            <WebGPUStatusPanel result={webgpuProbe} />
           )}
         </CanvasErrorBoundary>
       </div>

--- a/src/utils/webgpuSession.ts
+++ b/src/utils/webgpuSession.ts
@@ -1,0 +1,84 @@
+export type WebGPUSessionProbeFailure =
+  | 'unsupported'
+  | 'adapter-unavailable'
+  | 'canvas-context-unavailable'
+  | 'preferred-format-unavailable';
+
+export type WebGPUSessionProbeResult = {
+  ok: boolean;
+  failure: WebGPUSessionProbeFailure | null;
+  message: string;
+};
+
+type ProbeOptions = {
+  canvas?: HTMLCanvasElement | null;
+  compatibility?: boolean;
+};
+
+export const WEBGPU_SESSION_RECOVERY_HINT =
+  'Hard reload this tab, reopen the in-app browser, or restart the host app if the GPU session is stale.';
+
+export async function probeWebGPUSession({
+  canvas = null,
+  compatibility = false,
+}: ProbeOptions = {}): Promise<WebGPUSessionProbeResult> {
+  const gpu = typeof navigator !== 'undefined' ? (navigator as Navigator & { gpu?: GPU }).gpu : undefined;
+  if (!gpu?.requestAdapter) {
+    return {
+      ok: false,
+      failure: 'unsupported',
+      message: 'WebGPU is not available in this browser session.',
+    };
+  }
+
+  if (typeof document === 'undefined') {
+    return {
+      ok: false,
+      failure: 'unsupported',
+      message: 'WebGPU probing requires a browser document context.',
+    };
+  }
+
+  try {
+    const adapter = await gpu.requestAdapter(compatibility ? { featureLevel: 'compatibility' } : undefined);
+    if (!adapter) {
+      return {
+        ok: false,
+        failure: 'adapter-unavailable',
+        message: `WebGPU is exposed, but no adapter is available in this page session. ${WEBGPU_SESSION_RECOVERY_HINT}`,
+      };
+    }
+  } catch {
+    return {
+      ok: false,
+      failure: 'adapter-unavailable',
+      message: `WebGPU adapter probing failed in this page session. ${WEBGPU_SESSION_RECOVERY_HINT}`,
+    };
+  }
+
+  const probeCanvas = canvas ?? document.createElement('canvas');
+  const context = probeCanvas.getContext('webgpu');
+  if (!context) {
+    return {
+      ok: false,
+      failure: 'canvas-context-unavailable',
+      message: `WebGPU adapter exists, but this page cannot create a WebGPU canvas context provider. ${WEBGPU_SESSION_RECOVERY_HINT}`,
+    };
+  }
+
+  try {
+    gpu.getPreferredCanvasFormat();
+  } catch {
+    return {
+      ok: false,
+      failure: 'preferred-format-unavailable',
+      message: `WebGPU adapter and context exist, but no preferred canvas format is available. ${WEBGPU_SESSION_RECOVERY_HINT}`,
+    };
+  }
+
+  return {
+    ok: true,
+    failure: null,
+    message: 'WebGPU session preflight succeeded.',
+  };
+}


### PR DESCRIPTION
Closes #1

## Summary
- adds a shared WebGPU session preflight for adapter, canvas context, and preferred-format checks
- gates the Beauty WebGPU Lab before renderer creation and shows an actionable stale-session recovery state
- routes the Material Parity WebGPU side through the same preflight and removes the Windows `powerPreference` warning source

## Validation
- `pnpm lint`
- `pnpm build`
- Browser smoke: `/labs/beauty-webgpu` opened with 0 console warnings/errors
- Browser smoke: `/labs/material-parity` opened with 0 console warnings/errors