### PR TITLE
[codex] Separate product and lab surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Eye Sim
 
-Eye Sim is a React + Three.js facial rendering sandbox for procedural eyes, MediaPipe-driven face tracking, and renderer/material investigation. The repo includes the main interactive app plus lab routes for material parity, beauty shading, and offline facecap conditioning.
+Eye Sim is a React + Three.js digital face rig presentation system with procedural eyes as the hero feature. The default route is the product surface: a polished face rig with opt-in tracking, focus modes, and release-safe controls.
+
+The repo also contains isolated lab routes under `/labs/*` for material parity, beauty shading, WebGPU diagnostics, and offline Facecap conditioning. Labs are intentionally separated from the default experience and may be unstable or renderer-specific.
 
 ## Stack
 
@@ -30,7 +32,13 @@ Prerequisite: Node.js 22+ and `pnpm`.
 ## Project Layout
 
 - `src/routes/` contains the main app route and lab routes.
+- `src/routes/MainRoute.tsx` is the product surface.
+- `src/routes/*LabRoute.tsx` and other `/labs/*` routes are investigation surfaces, not product defaults.
 - `src/features/tracking/` contains the MediaPipe tracking pipeline.
 - `src/features/face/` contains face runtime, eye-fit, and material modules.
 - `data/conditioning/` stores generated conditioning payloads and manifests.
 - `scripts/conditioning/probes/` contains one-off inspection probes for the conditioning bake.
+
+## Product/Lab Boundary
+
+The Beauty WebGPU Lab should stay in this repo until the shot system and face rig runtime stabilize. It should become a separate package only if it starts needing its own renderer lifecycle, asset bake cadence, or shader test harness that would slow down the main face rig release path.

--- a/src/components/AppNav.tsx
+++ b/src/components/AppNav.tsx
@@ -1,5 +1,5 @@
 import { NavLink } from 'react-router-dom';
-import { APP_NAV_ITEMS } from '../routes/routeConfig';
+import { LAB_NAV_ITEMS, PRODUCT_NAV_ITEMS } from '../routes/routeConfig';
 
 type AppNavProps = {
   className?: string;
@@ -7,8 +7,11 @@ type AppNavProps = {
 
 export default function AppNav({ className = '' }: AppNavProps) {
   return (
-    <div className={`flex max-w-[calc(100vw-2rem)] flex-wrap gap-1.5 rounded-[1.45rem] border border-white/10 bg-black/45 px-3 py-2 text-xs backdrop-blur-xl sm:gap-2 sm:rounded-full sm:text-sm ${className}`.trim()}>
-      {APP_NAV_ITEMS.map((item) => (
+    <nav
+      aria-label="App navigation"
+      className={`flex max-w-[calc(100vw-2rem)] flex-wrap items-center gap-1.5 rounded-[1.45rem] border border-white/10 bg-black/45 px-3 py-2 text-xs backdrop-blur-xl sm:gap-2 sm:rounded-full sm:text-sm ${className}`.trim()}
+    >
+      {PRODUCT_NAV_ITEMS.map((item) => (
         <NavLink
           key={item.to}
           to={item.to}
@@ -21,6 +24,23 @@ export default function AppNav({ className = '' }: AppNavProps) {
           {item.label}
         </NavLink>
       ))}
-    </div>
+      <span className="mx-1 hidden h-4 w-px bg-white/15 sm:inline-block" aria-hidden="true" />
+      <span className="rounded-full border border-amber-300/15 bg-amber-300/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-amber-100/70">
+        Labs
+      </span>
+      {LAB_NAV_ITEMS.map((item) => (
+        <NavLink
+          key={item.to}
+          to={item.to}
+          className={({ isActive }) => (
+            isActive
+              ? 'rounded-full bg-amber-300/16 px-3 py-1 text-amber-50'
+              : 'rounded-full px-3 py-1 text-stone-300 transition hover:bg-amber-300/10 hover:text-amber-50'
+          )}
+        >
+          {item.label}
+        </NavLink>
+      ))}
+    </nav>
   );
 }

--- a/src/routes/AssetConditioningRoute.tsx
+++ b/src/routes/AssetConditioningRoute.tsx
@@ -44,7 +44,7 @@ export default function AssetConditioningRoute() {
 
         <div className="mt-10 grid gap-8 lg:grid-cols-[1.2fr_0.8fr]">
           <section className="rounded-[2rem] border border-white/10 bg-[radial-gradient(circle_at_top_left,_rgba(251,191,36,0.12),_transparent_38%),linear-gradient(180deg,rgba(255,255,255,0.04),rgba(255,255,255,0.01))] p-8 shadow-2xl shadow-black/20">
-            <p className="text-xs uppercase tracking-[0.32em] text-stone-400">Clean Page</p>
+            <p className="text-xs uppercase tracking-[0.32em] text-amber-200/70">Lab Route</p>
             <h1 className="mt-3 max-w-3xl text-4xl font-semibold tracking-tight text-stone-50">Offline Asset Conditioning Pipeline</h1>
             <p className="mt-4 max-w-3xl text-base leading-7 text-stone-300">
               This route replaces the failed coordinate-hack approach with an asset-first pipeline. Facial regions should be authored once, baked into stable data, and only modulated at runtime. The beauty lab should consume conditioned inputs, not discover anatomy from shared materials and raw vertex positions.

--- a/src/routes/BeautyMaterialLabRoute.tsx
+++ b/src/routes/BeautyMaterialLabRoute.tsx
@@ -32,6 +32,9 @@ function RouteShell({
     <div className="relative h-screen w-full overflow-hidden bg-[#1a1a1e] text-stone-100">
       <div className="absolute left-0 right-0 top-0 z-30 flex items-center justify-between px-4 py-3">
         <AppNav />
+        <div className="pointer-events-none hidden rounded-full border border-amber-300/15 bg-amber-300/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.22em] text-amber-100/75 md:block">
+          Isolated Lab Route
+        </div>
         <div className="flex items-center gap-1 border border-white/10 bg-black/60 p-0.5">
           <button
             onClick={() => setMode('baseline')}

--- a/src/routes/routeConfig.ts
+++ b/src/routes/routeConfig.ts
@@ -1,6 +1,9 @@
 export const APP_NAV_ITEMS = [
-  { to: '/', label: 'Main App' },
-  { to: '/labs/beauty-webgpu', label: 'Beauty WebGPU Lab' },
-  { to: '/labs/material-parity', label: 'Material Parity' },
-  { to: '/labs/asset-conditioning', label: 'Asset Conditioning' },
+  { to: '/', label: 'Main App', surface: 'product' },
+  { to: '/labs/beauty-webgpu', label: 'Beauty WebGPU', surface: 'lab' },
+  { to: '/labs/material-parity', label: 'Material Parity', surface: 'lab' },
+  { to: '/labs/asset-conditioning', label: 'Asset Conditioning', surface: 'lab' },
 ] as const;
+
+export const PRODUCT_NAV_ITEMS = APP_NAV_ITEMS.filter((item) => item.surface === 'product');
+export const LAB_NAV_ITEMS = APP_NAV_ITEMS.filter((item) => item.surface === 'lab');


### PR DESCRIPTION
Closes #2

## Summary
- separates the main product nav item from lab routes with explicit nav metadata and a lab badge
- marks the Beauty WebGPU and Asset Conditioning routes as isolated lab surfaces
- updates README framing so `MainRoute` is the product surface and `/labs/*` routes are investigation surfaces
- records the current decision to keep the Beauty WebGPU Lab in-repo until the shot system and face rig runtime stabilize

## Validation
- `pnpm lint`
- `pnpm build`
- Browser smoke: `/` shows product/lab nav separation
- Browser smoke: `/labs/asset-conditioning` shows lab route framing with 0 console errors