### PR TITLE
Introduce presentation shots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Eye Sim
 
-Eye Sim is a React + Three.js digital face rig presentation system with procedural eyes as the hero feature. The default route is the product surface: a polished face rig with opt-in tracking, focus modes, and release-safe controls.
+Eye Sim is a React + Three.js digital face rig presentation system with procedural eyes as the hero feature. The default route is the product surface: a polished face rig with opt-in tracking, shot-based presentation modes, and release-safe controls.
 
 The repo also contains isolated lab routes under `/labs/*` for material parity, beauty shading, WebGPU diagnostics, and offline Facecap conditioning. Labs are intentionally separated from the default experience and may be unstable or renderer-specific.
 
@@ -34,6 +34,7 @@ Prerequisite: Node.js 22+ and `pnpm`.
 - `src/routes/` contains the main app route and lab routes.
 - `src/routes/MainRoute.tsx` is the product surface.
 - `src/routes/*LabRoute.tsx` and other `/labs/*` routes are investigation surfaces, not product defaults.
+- `src/features/presentation/` contains shot definitions for camera framing, scale, defaults, and release-safe interaction boundaries.
 - `src/features/tracking/` contains the MediaPipe tracking pipeline.
 - `src/features/face/` contains face runtime, eye-fit, and material modules.
 - `data/conditioning/` stores generated conditioning payloads and manifests.

--- a/src/components/UI.tsx
+++ b/src/components/UI.tsx
@@ -13,8 +13,13 @@ import {
   UserRound,
   Video,
 } from 'lucide-react';
-
-type FocusMode = 'portrait' | 'eyes' | 'mouth';
+import {
+  PRESENTATION_SHOT_ORDER,
+  PRESENTATION_SHOTS,
+  type AnimationMode,
+  type LightingMode,
+  type PresentationShotId,
+} from '../features/presentation/shots';
 
 interface UIProps {
   color1: string;
@@ -29,8 +34,8 @@ interface UIProps {
   setThickness: (v: number) => void;
   screenBrightness: number;
   setScreenBrightness: (v: number) => void;
-  lightingMode: 'studio' | 'outdoor';
-  setLightingMode: (v: 'studio' | 'outdoor') => void;
+  lightingMode: LightingMode;
+  setLightingMode: (v: LightingMode) => void;
   trackingEnabled: boolean;
   setTrackingEnabled: (v: boolean) => void;
   trackingStatus: 'idle' | 'loading' | 'tracking' | 'error';
@@ -38,12 +43,12 @@ interface UIProps {
   setDebugOverlayEnabled: (v: boolean) => void;
   videoEnvEnabled: boolean;
   setVideoEnvEnabled: (v: boolean) => void;
-  animationMode: 'mouse' | 'calm' | 'saccades' | 'scanning';
-  setAnimationMode: (v: 'mouse' | 'calm' | 'saccades' | 'scanning') => void;
+  animationMode: AnimationMode;
+  setAnimationMode: (v: AnimationMode) => void;
   pupilSize: number;
   setPupilSize: (v: number) => void;
-  focusMode: FocusMode;
-  setFocusMode: (v: FocusMode) => void;
+  activeShot: PresentationShotId;
+  setActiveShot: (v: PresentationShotId) => void;
   advancedRigOpen: boolean;
   setAdvancedRigOpen: (v: boolean) => void;
 }
@@ -57,11 +62,21 @@ const PRESETS = [
   { name: 'Amber', c1: '#5a2106', c2: '#f6b44d' },
 ];
 
-const FOCUS_OPTIONS: Array<{ value: FocusMode; label: string; icon: LucideIcon }> = [
-  { value: 'portrait', label: 'Face', icon: UserRound },
-  { value: 'eyes', label: 'Eyes', icon: Eye },
-  { value: 'mouth', label: 'Mouth', icon: Smile },
-];
+const SHOT_ICONS: Record<PresentationShotId, LucideIcon> = {
+  portrait: UserRound,
+  eyes: Eye,
+  mouth: Smile,
+  trackingTwin: Activity,
+  inspect: SlidersHorizontal,
+};
+
+const SHOT_OPTIONS = PRESENTATION_SHOT_ORDER.map((value) => ({
+  value,
+  label: PRESENTATION_SHOTS[value].shortLabel,
+  title: PRESENTATION_SHOTS[value].label,
+  description: PRESENTATION_SHOTS[value].description,
+  icon: SHOT_ICONS[value],
+}));
 
 const LIGHTING_OPTIONS: Array<{ value: UIProps['lightingMode']; label: string; icon: LucideIcon }> = [
   { value: 'studio', label: 'Studio', icon: Sparkles },
@@ -194,11 +209,13 @@ export default function UI({
   setAnimationMode,
   pupilSize,
   setPupilSize,
-  focusMode,
-  setFocusMode,
+  activeShot,
+  setActiveShot,
   advancedRigOpen,
   setAdvancedRigOpen,
 }: UIProps) {
+  const activeShotConfig = PRESENTATION_SHOTS[activeShot];
+
   return (
     <>
       <div className="pointer-events-none absolute inset-0 z-10 bg-[radial-gradient(circle_at_50%_16%,rgba(255,241,219,0.09),transparent_30%),linear-gradient(180deg,rgba(0,0,0,0.18),transparent_38%,rgba(0,0,0,0.42))]" />
@@ -214,7 +231,7 @@ export default function UI({
           <div className="flex items-start justify-between gap-3">
             <div>
               <h1 className="text-base font-semibold tracking-tight text-white">Digital face rig</h1>
-              <p className="mt-0.5 text-xs text-white/46">{trackingEnabled ? 'Live twin mode' : 'Presentation mode'}</p>
+              <p className="mt-0.5 text-xs text-white/46">{activeShotConfig.description}</p>
             </div>
             <div className="flex items-center gap-2 rounded-full border border-white/10 bg-black/30 px-2.5 py-1.5 text-[10px] uppercase tracking-[0.14em] text-white/60">
               <StatusDot enabled={trackingEnabled} status={trackingStatus} />
@@ -222,16 +239,17 @@ export default function UI({
             </div>
           </div>
 
-          <div className="mt-3 grid grid-cols-3 gap-1 rounded-full border border-white/8 bg-black/22 p-1">
-            {FOCUS_OPTIONS.map(({ value, label, icon: Icon }) => (
+          <div className="mt-3 grid grid-cols-5 gap-1 rounded-full border border-white/8 bg-black/22 p-1">
+            {SHOT_OPTIONS.map(({ value, label, title, description, icon: Icon }) => (
               <button
                 key={value}
                 type="button"
-                onClick={() => setFocusMode(value)}
-                aria-label={`${label} view`}
+                onClick={() => setActiveShot(value)}
+                aria-label={`${title} shot`}
+                title={description}
                 className={cx(
-                  'flex items-center justify-center gap-1.5 rounded-full px-2 py-2 text-xs font-semibold transition',
-                  focusMode === value ? 'bg-white text-neutral-950' : 'text-white/56 hover:bg-white/8 hover:text-white',
+                  'flex items-center justify-center gap-1 rounded-full px-1.5 py-2 text-[10px] font-semibold transition',
+                  activeShot === value ? 'bg-white text-neutral-950' : 'text-white/56 hover:bg-white/8 hover:text-white',
                 )}
               >
                 <Icon className="h-3.5 w-3.5" />
@@ -344,9 +362,7 @@ export default function UI({
               <div className="mb-3 flex items-start justify-between gap-3">
                 <div>
                   <h1 className="text-lg font-semibold tracking-tight text-white">Digital face rig</h1>
-                  <p className="mt-0.5 text-xs text-white/46">
-                    {trackingEnabled ? 'Live twin mode' : 'Presentation mode'}
-                  </p>
+                  <p className="mt-0.5 text-xs text-white/46">{activeShotConfig.description}</p>
                 </div>
                 <div className="flex items-center gap-2 rounded-full border border-white/10 bg-black/30 px-2.5 py-1.5 text-[10px] uppercase tracking-[0.14em] text-white/60">
                   <StatusDot enabled={trackingEnabled} status={trackingStatus} />
@@ -438,16 +454,18 @@ export default function UI({
             </div>
 
             <div className="rounded-[1.2rem] border border-white/8 bg-white/[0.035] p-3">
-              <SectionLabel icon={Eye}>View</SectionLabel>
-              <div className="grid grid-cols-3 gap-1 rounded-full border border-white/8 bg-black/22 p-1">
-                {FOCUS_OPTIONS.map(({ value, label, icon: Icon }) => (
+              <SectionLabel icon={Eye}>Shot</SectionLabel>
+              <div className="grid grid-cols-5 gap-1 rounded-full border border-white/8 bg-black/22 p-1">
+                {SHOT_OPTIONS.map(({ value, label, title, description, icon: Icon }) => (
                   <button
                     key={value}
                     type="button"
-                    onClick={() => setFocusMode(value)}
+                    onClick={() => setActiveShot(value)}
+                    aria-label={`${title} shot`}
+                    title={description}
                     className={cx(
-                      'flex items-center justify-center gap-1.5 rounded-full px-2 py-2 text-xs font-semibold transition',
-                      focusMode === value ? 'bg-white text-neutral-950' : 'text-white/56 hover:bg-white/8 hover:text-white',
+                      'flex items-center justify-center gap-1.5 rounded-full px-2 py-2 text-[11px] font-semibold transition',
+                      activeShot === value ? 'bg-white text-neutral-950' : 'text-white/56 hover:bg-white/8 hover:text-white',
                     )}
                   >
                     <Icon className="h-3.5 w-3.5" />

--- a/src/features/presentation/shots.ts
+++ b/src/features/presentation/shots.ts
@@ -1,0 +1,207 @@
+export type PresentationShotId = 'portrait' | 'eyes' | 'mouth' | 'trackingTwin' | 'inspect';
+
+export type LightingMode = 'studio' | 'outdoor';
+
+export type AnimationMode = 'mouse' | 'calm' | 'saccades' | 'scanning';
+
+export type Vec3Tuple = [number, number, number];
+
+export type PresentationPreset = {
+  camera: Vec3Tuple;
+  target: Vec3Tuple;
+  facePosition: Vec3Tuple;
+  faceScale: number;
+};
+
+export type ShotControlPanel = 'capture' | 'iris' | 'lighting' | 'animation' | 'optics' | 'rig';
+
+export type PresentationShot = {
+  id: PresentationShotId;
+  label: string;
+  shortLabel: string;
+  description: string;
+  desktop: PresentationPreset;
+  compact: PresentationPreset;
+  defaults: {
+    lightingMode: LightingMode;
+    animationMode: AnimationMode;
+    trackingEnabled: boolean;
+    videoEnvEnabled: boolean;
+    debugOverlayEnabled: boolean;
+    advancedRigOpen: boolean;
+  };
+  allowedPanels: ShotControlPanel[];
+  mouthSafety: {
+    jawOpenMax: number;
+    smileMax: number;
+    description: string;
+  };
+};
+
+const DEFAULT_MOUTH_SAFETY: PresentationShot['mouthSafety'] = {
+  jawOpenMax: 0.36,
+  smileMax: 0.44,
+  description: 'Keep the current Facecap mouth interior out of extreme expression ranges.',
+};
+
+export const PRESENTATION_SHOTS: Record<PresentationShotId, PresentationShot> = {
+  portrait: {
+    id: 'portrait',
+    label: 'Portrait',
+    shortLabel: 'Face',
+    description: 'Balanced hero framing for the full digital face rig.',
+    desktop: {
+      camera: [0, 0.04, 8.7],
+      target: [0, -0.03, 0],
+      facePosition: [0, -0.35, 0],
+      faceScale: 1.62,
+    },
+    compact: {
+      camera: [0, 0.04, 9.35],
+      target: [0, -0.02, 0],
+      facePosition: [0, -0.24, 0],
+      faceScale: 1.22,
+    },
+    defaults: {
+      lightingMode: 'studio',
+      animationMode: 'mouse',
+      trackingEnabled: false,
+      videoEnvEnabled: false,
+      debugOverlayEnabled: false,
+      advancedRigOpen: false,
+    },
+    allowedPanels: ['capture', 'iris', 'lighting', 'animation', 'optics', 'rig'],
+    mouthSafety: DEFAULT_MOUTH_SAFETY,
+  },
+  eyes: {
+    id: 'eyes',
+    label: 'Eyes',
+    shortLabel: 'Eyes',
+    description: 'Close framing that keeps the iris and gaze system as the hero.',
+    desktop: {
+      camera: [0, 0.12, 6.95],
+      target: [0, 0.36, 0],
+      facePosition: [0, -0.98, 0],
+      faceScale: 2.42,
+    },
+    compact: {
+      camera: [0, 0.1, 7.7],
+      target: [0, 0.32, 0],
+      facePosition: [0, -0.72, 0],
+      faceScale: 1.72,
+    },
+    defaults: {
+      lightingMode: 'studio',
+      animationMode: 'saccades',
+      trackingEnabled: false,
+      videoEnvEnabled: false,
+      debugOverlayEnabled: false,
+      advancedRigOpen: false,
+    },
+    allowedPanels: ['iris', 'lighting', 'animation', 'optics', 'rig'],
+    mouthSafety: {
+      jawOpenMax: 0.18,
+      smileMax: 0.28,
+      description: 'Favor eye motion and avoid mouth expressions while the crop hides the lower face.',
+    },
+  },
+  mouth: {
+    id: 'mouth',
+    label: 'Mouth',
+    shortLabel: 'Mouth',
+    description: 'A constrained lower-face shot for checking lips without exposing bad dental geometry.',
+    desktop: {
+      camera: [0, -0.18, 6.85],
+      target: [0, -0.78, 0],
+      facePosition: [0, 0.25, 0],
+      faceScale: 2.26,
+    },
+    compact: {
+      camera: [0, -0.12, 7.45],
+      target: [0, -0.62, 0],
+      facePosition: [0, 0.08, 0],
+      faceScale: 1.66,
+    },
+    defaults: {
+      lightingMode: 'studio',
+      animationMode: 'calm',
+      trackingEnabled: false,
+      videoEnvEnabled: false,
+      debugOverlayEnabled: false,
+      advancedRigOpen: false,
+    },
+    allowedPanels: ['lighting', 'animation', 'optics', 'rig'],
+    mouthSafety: {
+      jawOpenMax: 0.22,
+      smileMax: 0.24,
+      description: 'Hold the lower face in a calm performance range until the asset mouth is replaced.',
+    },
+  },
+  trackingTwin: {
+    id: 'trackingTwin',
+    label: 'Tracking Twin',
+    shortLabel: 'Twin',
+    description: 'Webcam-driven presentation with a safer portrait crop and live status.',
+    desktop: {
+      camera: [0, 0.02, 8.25],
+      target: [0, -0.04, 0],
+      facePosition: [0, -0.32, 0],
+      faceScale: 1.72,
+    },
+    compact: {
+      camera: [0, 0.04, 9.05],
+      target: [0, -0.02, 0],
+      facePosition: [0, -0.22, 0],
+      faceScale: 1.3,
+    },
+    defaults: {
+      lightingMode: 'studio',
+      animationMode: 'calm',
+      trackingEnabled: true,
+      videoEnvEnabled: false,
+      debugOverlayEnabled: false,
+      advancedRigOpen: false,
+    },
+    allowedPanels: ['capture', 'iris', 'lighting', 'optics', 'rig'],
+    mouthSafety: {
+      jawOpenMax: 0.2,
+      smileMax: 0.22,
+      description: 'Prefer stable head and eye motion over full mouth retargeting in live mode.',
+    },
+  },
+  inspect: {
+    id: 'inspect',
+    label: 'Material Inspect',
+    shortLabel: 'Inspect',
+    description: 'A neutral inspection shot that opens rig controls without entering the lab surface.',
+    desktop: {
+      camera: [0, 0.02, 7.45],
+      target: [0, 0.02, 0],
+      facePosition: [0, -0.5, 0],
+      faceScale: 1.9,
+    },
+    compact: {
+      camera: [0, 0.02, 8.35],
+      target: [0, 0.02, 0],
+      facePosition: [0, -0.36, 0],
+      faceScale: 1.42,
+    },
+    defaults: {
+      lightingMode: 'outdoor',
+      animationMode: 'scanning',
+      trackingEnabled: false,
+      videoEnvEnabled: false,
+      debugOverlayEnabled: false,
+      advancedRigOpen: true,
+    },
+    allowedPanels: ['capture', 'iris', 'lighting', 'animation', 'optics', 'rig'],
+    mouthSafety: DEFAULT_MOUTH_SAFETY,
+  },
+};
+
+export const PRESENTATION_SHOT_ORDER: PresentationShotId[] = ['portrait', 'eyes', 'mouth', 'trackingTwin', 'inspect'];
+
+export function getPresentationShotPreset(shotId: PresentationShotId, compactViewport: boolean) {
+  const shot = PRESENTATION_SHOTS[shotId];
+  return compactViewport ? shot.compact : shot.desktop;
+}

--- a/src/routes/MainRoute.tsx
+++ b/src/routes/MainRoute.tsx
@@ -12,62 +12,14 @@ import TrackingDebugOverlay from '../components/TrackingDebugOverlay';
 import UI from '../components/UI';
 import VideoFeedEnvironment from '../components/VideoFeedEnvironment';
 import type { FaceViewMode } from '../features/face/materials';
+import {
+  getPresentationShotPreset,
+  PRESENTATION_SHOTS,
+  type AnimationMode,
+  type LightingMode,
+  type PresentationShotId,
+} from '../features/presentation/shots';
 import { type FaceTwinTracking, useMediaPipeFaceTwin } from '../hooks/useMediaPipeFaceTwin';
-
-type FocusMode = 'portrait' | 'eyes' | 'mouth';
-
-type PresentationPreset = {
-  camera: THREE.Vector3;
-  target: THREE.Vector3;
-  facePosition: [number, number, number];
-  faceScale: number;
-};
-
-const DESKTOP_PRESENTATION_PRESETS: Record<FocusMode, PresentationPreset> = {
-  portrait: {
-    camera: new THREE.Vector3(0, 0.04, 8.7),
-    target: new THREE.Vector3(0, -0.03, 0),
-    facePosition: [0, -0.35, 0],
-    faceScale: 1.62,
-  },
-  eyes: {
-    camera: new THREE.Vector3(0, 0.12, 6.95),
-    target: new THREE.Vector3(0, 0.36, 0),
-    facePosition: [0, -0.98, 0],
-    faceScale: 2.42,
-  },
-  mouth: {
-    camera: new THREE.Vector3(0, -0.18, 6.85),
-    target: new THREE.Vector3(0, -0.78, 0),
-    facePosition: [0, 0.25, 0],
-    faceScale: 2.26,
-  },
-};
-
-const COMPACT_PRESENTATION_PRESETS: Record<FocusMode, PresentationPreset> = {
-  portrait: {
-    camera: new THREE.Vector3(0, 0.04, 9.35),
-    target: new THREE.Vector3(0, -0.02, 0),
-    facePosition: [0, -0.24, 0],
-    faceScale: 1.22,
-  },
-  eyes: {
-    camera: new THREE.Vector3(0, 0.1, 7.7),
-    target: new THREE.Vector3(0, 0.32, 0),
-    facePosition: [0, -0.72, 0],
-    faceScale: 1.72,
-  },
-  mouth: {
-    camera: new THREE.Vector3(0, -0.12, 7.45),
-    target: new THREE.Vector3(0, -0.62, 0),
-    facePosition: [0, 0.08, 0],
-    faceScale: 1.66,
-  },
-};
-
-function getPresentationPreset(focusMode: FocusMode, compactViewport: boolean) {
-  return compactViewport ? COMPACT_PRESENTATION_PRESETS[focusMode] : DESKTOP_PRESENTATION_PRESETS[focusMode];
-}
 
 function SceneGrade({ screenBrightness, exposure, environmentIntensity }: { screenBrightness: number; exposure: number; environmentIntensity: number }) {
   const { gl, scene } = useThree();
@@ -103,23 +55,24 @@ function useCompactViewport() {
 
 function PresentationCameraRig({
   faceTracking,
-  focusMode,
+  activeShot,
   compactViewport,
 }: {
   faceTracking: FaceTwinTracking | null;
-  focusMode: FocusMode;
+  activeShot: PresentationShotId;
   compactViewport: boolean;
 }) {
   const { camera } = useThree();
   const stableProximityRef = useRef(0.5);
 
   useEffect(() => {
-    camera.position.copy(DESKTOP_PRESENTATION_PRESETS.portrait.camera);
-    camera.lookAt(DESKTOP_PRESENTATION_PRESETS.portrait.target);
+    const initialPreset = PRESENTATION_SHOTS.portrait.desktop;
+    camera.position.set(...initialPreset.camera);
+    camera.lookAt(...initialPreset.target);
   }, [camera]);
 
   useFrame((_, delta) => {
-    const preset = getPresentationPreset(focusMode, compactViewport);
+    const preset = getPresentationShotPreset(activeShot, compactViewport);
     const isTracking = faceTracking?.status === 'tracking';
     const proximity = isTracking ? faceTracking.proximity : 0.5;
     const proximityDelta = proximity - stableProximityRef.current;
@@ -129,13 +82,13 @@ function PresentationCameraRig({
     }
 
     const normalized = THREE.MathUtils.clamp((stableProximityRef.current - 0.5) / 0.38, -1, 1);
-    const trackingZ = THREE.MathUtils.clamp(preset.camera.z - normalized * 0.82, preset.camera.z - 0.75, preset.camera.z + 0.42);
+    const trackingZ = THREE.MathUtils.clamp(preset.camera[2] - normalized * 0.82, preset.camera[2] - 0.75, preset.camera[2] + 0.42);
 
     const damping = 1 - Math.exp(-delta * 3.2);
-    camera.position.x = THREE.MathUtils.lerp(camera.position.x, preset.camera.x, damping);
-    camera.position.y = THREE.MathUtils.lerp(camera.position.y, preset.camera.y, damping);
+    camera.position.x = THREE.MathUtils.lerp(camera.position.x, preset.camera[0], damping);
+    camera.position.y = THREE.MathUtils.lerp(camera.position.y, preset.camera[1], damping);
     camera.position.z = THREE.MathUtils.lerp(camera.position.z, trackingZ, damping);
-    camera.lookAt(preset.target);
+    camera.lookAt(...preset.target);
   });
 
   return null;
@@ -148,14 +101,14 @@ export default function MainRoute() {
   const [ior, setIor] = useState(1.376);
   const [thickness, setThickness] = useState(0.1);
   const [screenBrightness, setScreenBrightness] = useState(1.0);
-  const [lightingMode, setLightingMode] = useState<'studio' | 'outdoor'>('studio');
-  const [animationMode, setAnimationMode] = useState<'mouse' | 'calm' | 'saccades' | 'scanning'>('mouse');
+  const [lightingMode, setLightingMode] = useState<LightingMode>('studio');
+  const [animationMode, setAnimationMode] = useState<AnimationMode>('mouse');
   const [pupilSize, setPupilSize] = useState(0.15);
   const [trackingEnabled, setTrackingEnabled] = useState(false);
   const [videoEnvEnabled, setVideoEnvEnabled] = useState(false);
   const [debugOverlayEnabled, setDebugOverlayEnabled] = useState(false);
   const [advancedRigOpen, setAdvancedRigOpen] = useState(false);
-  const [focusMode, setFocusMode] = useState<FocusMode>('portrait');
+  const [activeShot, setActiveShot] = useState<PresentationShotId>('portrait');
   const [effectsEnabled] = useState(false);
   const compactViewport = useCompactViewport();
 
@@ -180,7 +133,19 @@ export default function MainRoute() {
     cubemapIntensity: number;
   };
 
-  const presentation = getPresentationPreset(focusMode, compactViewport);
+  const presentation = getPresentationShotPreset(activeShot, compactViewport);
+
+  const applyPresentationShot = (shotId: PresentationShotId) => {
+    const { defaults } = PRESENTATION_SHOTS[shotId];
+
+    setActiveShot(shotId);
+    setLightingMode(defaults.lightingMode);
+    setAnimationMode(defaults.animationMode);
+    setTrackingEnabled(defaults.trackingEnabled);
+    setVideoEnvEnabled(defaults.videoEnvEnabled);
+    setDebugOverlayEnabled(defaults.debugOverlayEnabled);
+    setAdvancedRigOpen(defaults.advancedRigOpen);
+  };
 
   return (
     <div className="relative h-screen w-full overflow-hidden bg-neutral-950 text-white">
@@ -196,7 +161,7 @@ export default function MainRoute() {
           {showStats && <Stats />}
           <AdaptiveDpr />
           <SceneGrade screenBrightness={screenBrightness} exposure={renderExposure} environmentIntensity={cubemapIntensity} />
-          <PresentationCameraRig faceTracking={trackingEnabled ? faceTracking : null} focusMode={focusMode} compactViewport={compactViewport} />
+          <PresentationCameraRig faceTracking={trackingEnabled ? faceTracking : null} activeShot={activeShot} compactViewport={compactViewport} />
 
           {lightingMode === 'studio' ? (
             <>
@@ -263,8 +228,8 @@ export default function MainRoute() {
         setAnimationMode={setAnimationMode}
         pupilSize={pupilSize}
         setPupilSize={setPupilSize}
-        focusMode={focusMode}
-        setFocusMode={setFocusMode}
+        activeShot={activeShot}
+        setActiveShot={applyPresentationShot}
         advancedRigOpen={advancedRigOpen}
         setAdvancedRigOpen={setAdvancedRigOpen}
       />


### PR DESCRIPTION
## Summary
- Add typed presentation shot definitions for Portrait, Eyes, Mouth, Tracking Twin, and Material Inspect.
- Move camera framing, face scale, shot defaults, allowed panels, and mouth-safety metadata into `src/features/presentation/shots.ts`.
- Replace the main UI focus switch with a shot selector on desktop and mobile.
- Apply shot-owned lighting, animation, tracking, video reflection, debug, and rig defaults when a shot is selected.
- Update README language from focus modes to shot-based presentation modes.

Closes #3.

## Validation
- `pnpm lint`
- `pnpm build`
- Playwright CLI smoke on `/`: verified five shot buttons render, Mouth and Material Inspect switch correctly, Portrait resets inspection state, mobile shot selector renders at 390x844, console reported 0 errors and 0 warnings.