### PR TITLE
Contain Facecap mouth exposure

### DIFF
--- a/src/components/Face.tsx
+++ b/src/components/Face.tsx
@@ -38,6 +38,7 @@ import {
   type EyeRotationLimits,
   type EyeRotationLimitsMutable,
 } from '../features/face/eyeFit';
+import type { MouthSafetyProfile } from '../features/face/mouthSafety';
 import Eye from './Eye';
 
 const FACECAP_URL = 'https://raw.githubusercontent.com/mrdoob/three.js/master/examples/models/gltf/facecap.glb';
@@ -49,6 +50,7 @@ export type FaceProps = ThreeElements['group'] & {
   showCustomEyes?: boolean;
   eyeProps: FaceEyeProps;
   faceTracking?: FaceTwinTracking | null;
+  mouthSafety?: MouthSafetyProfile;
 };
 
 export default function Face({
@@ -56,6 +58,7 @@ export default function Face({
   showCustomEyes = true,
   eyeProps,
   faceTracking,
+  mouthSafety,
   ...props
 }: FaceProps) {
   const gl = useThree((state) => state.gl);
@@ -364,7 +367,7 @@ export default function Face({
       rawMorphValues[key] = nextValue;
     }
 
-    const nextMorphValues = adaptFacecapBlendshapes(rawMorphValues);
+    const nextMorphValues = adaptFacecapBlendshapes(rawMorphValues, mouthSafety);
 
     for (const key of FACS_CONTROL_KEYS) {
       if (Math.abs(nextMorphValues[key] - previousMorphValuesRef.current[key]) > 0.001) {

--- a/src/features/face/materials.ts
+++ b/src/features/face/materials.ts
@@ -1,4 +1,9 @@
 import * as THREE from 'three';
+import {
+  applyMouthSafetyProfile,
+  DEFAULT_MOUTH_SAFETY_PROFILE,
+  type MouthSafetyProfile,
+} from './mouthSafety';
 
 export const FACS_CONTROL_KEYS = [
   'eyeBlink_L',
@@ -338,7 +343,10 @@ export function updateSkinUniforms(
   uniforms.deepTint.value.copy(SKIN_COLOR_DEEP).lerp(SKIN_COLOR_FLUSH, uniforms.flushStrength.value * 0.08);
 }
 
-export function adaptFacecapBlendshapes(blendshapes: Record<FacsControlKey, number>) {
+export function adaptFacecapBlendshapes(
+  blendshapes: Record<FacsControlKey, number>,
+  mouthSafety: MouthSafetyProfile = DEFAULT_MOUTH_SAFETY_PROFILE,
+) {
   const next = { ...blendshapes };
   const smile = Math.max(next.mouthSmile_L ?? 0, next.mouthSmile_R ?? 0);
   const stretch = Math.max(next.mouthStretch_L ?? 0, next.mouthStretch_R ?? 0);
@@ -363,16 +371,20 @@ export function adaptFacecapBlendshapes(blendshapes: Record<FacsControlKey, numb
   next.mouthPucker = THREE.MathUtils.clamp((next.mouthPucker ?? 0) * 0.82, 0, 0.58);
   next.tongueOut = THREE.MathUtils.clamp(next.tongueOut ?? 0, 0, 0.08);
 
-  return next;
+  return applyMouthSafetyProfile(next, mouthSafety);
 }
 
 export function isDentalCandidateMesh(mesh: THREE.Mesh, material: THREE.Material) {
   const combinedName = `${mesh.name} ${mesh.parent?.name ?? ''} ${material.name}`.toLowerCase();
-  return /(teeth|tooth|gum|tongue|mouthinner|mouth_inner|saliva)/.test(combinedName);
+  return mesh.name === 'mesh_3' || /(teeth|tooth|gum|tongue|mouthinner|mouth_inner|saliva)/.test(combinedName);
 }
 
 function isSkinCandidateMesh(mesh: THREE.Mesh, material: THREE.Material) {
   const combinedName = `${mesh.name} ${material.name}`.toLowerCase();
+  if (mesh.name === 'mesh_3') {
+    return false;
+  }
+
   if (/(eye|cornea|iris|pupil|teeth|tooth|gum|tongue|mouthinner|mouth_inner|saliva|lash)/.test(combinedName)) {
     return false;
   }
@@ -395,13 +407,13 @@ export function createDentalMaterial(originalMaterial: THREE.Material, mesh: THR
   const bboxMin = geometry.boundingBox?.min.clone() ?? new THREE.Vector3(-1, -1, -1);
   const bboxMax = geometry.boundingBox?.max.clone() ?? new THREE.Vector3(1, 1, 1);
   const material = new THREE.MeshPhysicalMaterial({
-    color: new THREE.Color('#efe7de'),
-    roughness: 0.34,
+    color: new THREE.Color('#e5d9cf'),
+    roughness: 0.62,
     metalness: 0,
-    envMapIntensity: 0.32,
-    clearcoat: 0.12,
-    clearcoatRoughness: 0.18,
-    ior: 1.53,
+    envMapIntensity: 0.16,
+    clearcoat: 0.04,
+    clearcoatRoughness: 0.38,
+    ior: 1.45,
   });
   material.name = `dental-${originalMaterial.name || mesh.name}`;
   material.onBeforeCompile = (shader) => {
@@ -440,17 +452,18 @@ float dentalBand(float value, float center, float radius, float blur) {
   float incisorMask = dentalBand(vDentalLocalPosition.x, 0.5, 0.22, 0.08);
   float gumMask = smoothstep(0.72, 0.98, vDentalLocalPosition.y) * (1.0 - dentalDepth * 0.45);
   float rootShadow = smoothstep(0.56, 0.92, vDentalLocalPosition.y) * smoothstep(0.35, 0.95, vDentalLocalPosition.z);
-  vec3 enamel = vec3(0.97, 0.95, 0.91);
-  vec3 dentin = vec3(0.86, 0.79, 0.72);
-  vec3 gumTint = vec3(0.52, 0.28, 0.28);
-  vec3 toothColor = mix(dentin, enamel, incisorMask * 0.45 + 0.4);
-  toothColor = mix(toothColor, gumTint, gumMask * 0.65);
-  toothColor *= 1.0 - rootShadow * 0.35;
-  diffuseColor.rgb = toothColor;
+  float mouthShadow = smoothstep(0.08, 0.72, vDentalLocalPosition.z) * (1.0 - incisorMask * 0.28);
+  vec3 enamel = vec3(0.91, 0.87, 0.80);
+  vec3 dentin = vec3(0.69, 0.60, 0.52);
+  vec3 gumTint = vec3(0.34, 0.18, 0.18);
+  vec3 toothColor = mix(dentin, enamel, incisorMask * 0.34 + 0.38);
+  toothColor = mix(toothColor, gumTint, gumMask * 0.48);
+  toothColor *= 1.0 - rootShadow * 0.48 - mouthShadow * 0.22;
+  diffuseColor.rgb = mix(diffuseColor.rgb, toothColor, 0.92);
 }`,
     );
   };
-  material.customProgramCacheKey = () => 'dental-v2';
+  material.customProgramCacheKey = () => 'dental-v3';
   return material;
 }
 

--- a/src/features/face/mouthSafety.ts
+++ b/src/features/face/mouthSafety.ts
@@ -1,0 +1,106 @@
+export type MouthSafetyProfile = {
+  jawOpenMax: number;
+  smileMax: number;
+  stretchMax: number;
+  lipRaiseMax: number;
+  lipDropMax: number;
+  puckerMax: number;
+  funnelMax: number;
+  tongueOutMax: number;
+  dentalExposureMax: number;
+  closedMouthBias: number;
+  description: string;
+};
+
+export const DEFAULT_MOUTH_SAFETY_PROFILE: MouthSafetyProfile = {
+  jawOpenMax: 0.34,
+  smileMax: 0.42,
+  stretchMax: 0.34,
+  lipRaiseMax: 0.12,
+  lipDropMax: 0.15,
+  puckerMax: 0.38,
+  funnelMax: 0.34,
+  tongueOutMax: 0.02,
+  dentalExposureMax: 0.26,
+  closedMouthBias: 0.08,
+  description: 'Keep the current Facecap mouth interior out of extreme expression ranges.',
+};
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function attenuateAbove(value: number, safeMax: number, softness: number) {
+  if (value <= safeMax) return value;
+  return safeMax + (value - safeMax) * softness;
+}
+
+function limitChannel(values: Record<string, number>, key: string, max: number) {
+  values[key] = clamp(values[key] ?? 0, 0, max);
+}
+
+function attenuateChannel(values: Record<string, number>, key: string, safeMax: number, softness: number) {
+  values[key] = clamp(attenuateAbove(values[key] ?? 0, safeMax, softness), 0, 1);
+}
+
+export function applyMouthSafetyProfile<T extends Record<string, number>>(
+  values: T,
+  profile: MouthSafetyProfile = DEFAULT_MOUTH_SAFETY_PROFILE,
+) {
+  const next = { ...values } as Record<string, number>;
+
+  limitChannel(next, 'jawOpen', profile.jawOpenMax);
+  limitChannel(next, 'jawForward', 0.12);
+  limitChannel(next, 'jawLeft', 0.18);
+  limitChannel(next, 'jawRight', 0.18);
+  limitChannel(next, 'mouthSmile_L', profile.smileMax);
+  limitChannel(next, 'mouthSmile_R', profile.smileMax);
+  limitChannel(next, 'mouthStretch_L', profile.stretchMax);
+  limitChannel(next, 'mouthStretch_R', profile.stretchMax);
+  limitChannel(next, 'mouthDimple_L', profile.smileMax * 0.62);
+  limitChannel(next, 'mouthDimple_R', profile.smileMax * 0.62);
+  limitChannel(next, 'mouthUpperUp_L', profile.lipRaiseMax);
+  limitChannel(next, 'mouthUpperUp_R', profile.lipRaiseMax);
+  limitChannel(next, 'mouthLowerDown_L', profile.lipDropMax);
+  limitChannel(next, 'mouthLowerDown_R', profile.lipDropMax);
+  limitChannel(next, 'mouthShrugUpper', profile.lipRaiseMax);
+  limitChannel(next, 'mouthShrugLower', profile.lipDropMax);
+  limitChannel(next, 'mouthRollUpper', Math.max(profile.lipRaiseMax, 0.12));
+  limitChannel(next, 'mouthRollLower', Math.max(profile.lipDropMax, 0.14));
+  limitChannel(next, 'mouthPucker', profile.puckerMax);
+  limitChannel(next, 'mouthFunnel', profile.funnelMax);
+  limitChannel(next, 'tongueOut', profile.tongueOutMax);
+
+  const dentalExposure = Math.max(
+    next.jawOpen ?? 0,
+    next.mouthUpperUp_L ?? 0,
+    next.mouthUpperUp_R ?? 0,
+    next.mouthLowerDown_L ?? 0,
+    next.mouthLowerDown_R ?? 0,
+    (next.mouthFunnel ?? 0) * 0.72,
+  );
+  const dentalRisk = clamp((dentalExposure - profile.dentalExposureMax) / Math.max(1 - profile.dentalExposureMax, 1e-5), 0, 1);
+
+  if (dentalRisk > 0) {
+    const lipOcclusion = 1 - dentalRisk * 0.44;
+    next.mouthUpperUp_L = (next.mouthUpperUp_L ?? 0) * lipOcclusion;
+    next.mouthUpperUp_R = (next.mouthUpperUp_R ?? 0) * lipOcclusion;
+    next.mouthLowerDown_L = (next.mouthLowerDown_L ?? 0) * lipOcclusion;
+    next.mouthLowerDown_R = (next.mouthLowerDown_R ?? 0) * lipOcclusion;
+    next.mouthClose = Math.max(next.mouthClose ?? 0, dentalRisk * profile.closedMouthBias);
+  }
+
+  const smileStrength = Math.max(next.mouthSmile_L ?? 0, next.mouthSmile_R ?? 0);
+  const openWhileSmiling = (next.jawOpen ?? 0) * smileStrength;
+  if (openWhileSmiling > 0.06) {
+    const smileOpenRisk = clamp((openWhileSmiling - 0.06) / 0.22, 0, 1);
+    next.jawOpen = (next.jawOpen ?? 0) * (1 - smileOpenRisk * 0.32);
+    next.mouthLowerDown_L = (next.mouthLowerDown_L ?? 0) * (1 - smileOpenRisk * 0.38);
+    next.mouthLowerDown_R = (next.mouthLowerDown_R ?? 0) * (1 - smileOpenRisk * 0.38);
+  }
+
+  attenuateChannel(next, 'mouthFrown_L', profile.smileMax * 0.72, 0.36);
+  attenuateChannel(next, 'mouthFrown_R', profile.smileMax * 0.72, 0.36);
+
+  return next as T;
+}

--- a/src/features/presentation/shots.ts
+++ b/src/features/presentation/shots.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_MOUTH_SAFETY_PROFILE, type MouthSafetyProfile } from '../face/mouthSafety';
+
 export type PresentationShotId = 'portrait' | 'eyes' | 'mouth' | 'trackingTwin' | 'inspect';
 
 export type LightingMode = 'studio' | 'outdoor';
@@ -31,17 +33,11 @@ export type PresentationShot = {
     advancedRigOpen: boolean;
   };
   allowedPanels: ShotControlPanel[];
-  mouthSafety: {
-    jawOpenMax: number;
-    smileMax: number;
-    description: string;
-  };
+  mouthSafety: MouthSafetyProfile;
 };
 
 const DEFAULT_MOUTH_SAFETY: PresentationShot['mouthSafety'] = {
-  jawOpenMax: 0.36,
-  smileMax: 0.44,
-  description: 'Keep the current Facecap mouth interior out of extreme expression ranges.',
+  ...DEFAULT_MOUTH_SAFETY_PROFILE,
 };
 
 export const PRESENTATION_SHOTS: Record<PresentationShotId, PresentationShot> = {
@@ -100,8 +96,16 @@ export const PRESENTATION_SHOTS: Record<PresentationShotId, PresentationShot> = 
     },
     allowedPanels: ['iris', 'lighting', 'animation', 'optics', 'rig'],
     mouthSafety: {
-      jawOpenMax: 0.18,
-      smileMax: 0.28,
+      jawOpenMax: 0.14,
+      smileMax: 0.24,
+      stretchMax: 0.18,
+      lipRaiseMax: 0.06,
+      lipDropMax: 0.07,
+      puckerMax: 0.18,
+      funnelMax: 0.16,
+      tongueOutMax: 0,
+      dentalExposureMax: 0.12,
+      closedMouthBias: 0.12,
       description: 'Favor eye motion and avoid mouth expressions while the crop hides the lower face.',
     },
   },
@@ -134,6 +138,14 @@ export const PRESENTATION_SHOTS: Record<PresentationShotId, PresentationShot> = 
     mouthSafety: {
       jawOpenMax: 0.22,
       smileMax: 0.24,
+      stretchMax: 0.2,
+      lipRaiseMax: 0.08,
+      lipDropMax: 0.1,
+      puckerMax: 0.2,
+      funnelMax: 0.18,
+      tongueOutMax: 0,
+      dentalExposureMax: 0.18,
+      closedMouthBias: 0.14,
       description: 'Hold the lower face in a calm performance range until the asset mouth is replaced.',
     },
   },
@@ -166,6 +178,14 @@ export const PRESENTATION_SHOTS: Record<PresentationShotId, PresentationShot> = 
     mouthSafety: {
       jawOpenMax: 0.2,
       smileMax: 0.22,
+      stretchMax: 0.2,
+      lipRaiseMax: 0.08,
+      lipDropMax: 0.09,
+      puckerMax: 0.2,
+      funnelMax: 0.18,
+      tongueOutMax: 0,
+      dentalExposureMax: 0.17,
+      closedMouthBias: 0.14,
       description: 'Prefer stable head and eye motion over full mouth retargeting in live mode.',
     },
   },

--- a/src/routes/MainRoute.tsx
+++ b/src/routes/MainRoute.tsx
@@ -133,6 +133,7 @@ export default function MainRoute() {
     cubemapIntensity: number;
   };
 
+  const activeShotConfig = PRESENTATION_SHOTS[activeShot];
   const presentation = getPresentationShotPreset(activeShot, compactViewport);
 
   const applyPresentationShot = (shotId: PresentationShotId) => {
@@ -188,6 +189,7 @@ export default function MainRoute() {
               viewMode={viewMode}
               showCustomEyes={showCustomEyes}
               faceTracking={trackingEnabled ? faceTracking : null}
+              mouthSafety={activeShotConfig.mouthSafety}
               eyeProps={{ color1, color2, envMapIntensity, ior, thickness, animationMode, pupilSize }}
             />
           </group>


### PR DESCRIPTION
## Summary
- Add a face-level mouth safety profile and apply it after Facecap blendshape adaptation.
- Wire each presentation shot to explicit jaw, smile, lip, pucker/funnel, tongue, and dental exposure limits.
- Route the active shot mouth safety profile into `Face` from `MainRoute`.
- Force the known Facecap `mesh_3` dental asset onto the dental material path and keep it out of the skin shader.
- Reduce dental/gum brightness, clearcoat, and red gum prominence so exposed geometry reads less uncanny.

Closes #4.

## Validation
- `pnpm lint`
- `pnpm build`
- Playwright CLI smoke on `/`: switched Mouth and Material Inspect shots, captured Mouth shot screenshot, console reported 0 errors and 0 warnings.