### PR TITLE
Add tracking adapter interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Prerequisite: Node.js 22+ and `pnpm`.
 - `src/routes/MainRoute.tsx` is the product surface.
 - `src/routes/*LabRoute.tsx` and other `/labs/*` routes are investigation surfaces, not product defaults.
 - `src/features/presentation/` contains shot definitions for camera framing, scale, defaults, and release-safe interaction boundaries.
-- `src/features/tracking/` contains the MediaPipe tracking pipeline.
+- `src/features/tracking/` contains the tracking adapter contract plus MediaPipe pipeline modules.
 - `src/features/face/` contains face runtime, eye-fit, and material modules.
 - `data/conditioning/` stores generated conditioning payloads and manifests.
 - `scripts/conditioning/probes/` contains one-off inspection probes for the conditioning bake.

--- a/src/features/tracking/adapters.ts
+++ b/src/features/tracking/adapters.ts
@@ -1,0 +1,79 @@
+import { INITIAL_TRACKING, type FaceTwinTracking } from './types';
+
+export type FaceTrackingAdapterId = 'mouse' | 'demo' | 'webcam';
+
+export type FaceTrackingAdapterDescriptor = {
+  id: FaceTrackingAdapterId;
+  label: string;
+  description: string;
+  requiresVideoCapture: boolean;
+  producesTrackedPose: boolean;
+};
+
+export const FACE_TRACKING_ADAPTERS: Record<FaceTrackingAdapterId, FaceTrackingAdapterDescriptor> = {
+  mouse: {
+    id: 'mouse',
+    label: 'Mouse',
+    description: 'Manual presentation mode; eye motion is driven by the local pointer and animation settings.',
+    requiresVideoCapture: false,
+    producesTrackedPose: false,
+  },
+  demo: {
+    id: 'demo',
+    label: 'Demo',
+    description: 'Deterministic synthetic head, gaze, and expression motion for demos without a camera.',
+    requiresVideoCapture: false,
+    producesTrackedPose: true,
+  },
+  webcam: {
+    id: 'webcam',
+    label: 'Webcam',
+    description: 'MediaPipe webcam driver for live face pose, gaze, and blendshape data.',
+    requiresVideoCapture: true,
+    producesTrackedPose: true,
+  },
+};
+
+export function createMouseTrackingFrame(videoElement: HTMLVideoElement | null = null): FaceTwinTracking {
+  return {
+    ...INITIAL_TRACKING,
+    status: 'idle',
+    videoElement,
+  };
+}
+
+export function createDemoTrackingFrame(timeSeconds: number): FaceTwinTracking {
+  const blinkPulse = Math.max(0, Math.sin(timeSeconds * 2.8) - 0.92) * 8.5;
+  const smile = 0.08 + Math.sin(timeSeconds * 0.6) * 0.025;
+  const jawOpen = 0.035 + Math.max(0, Math.sin(timeSeconds * 1.1)) * 0.035;
+  const gazeYaw = Math.sin(timeSeconds * 0.85) * 0.22;
+  const gazePitch = Math.sin(timeSeconds * 0.42) * 0.08;
+
+  return {
+    ...INITIAL_TRACKING,
+    status: 'tracking',
+    refinementConfidence: 1,
+    proximity: 0.52 + Math.sin(timeSeconds * 0.28) * 0.025,
+    blendshapes: {
+      eyeBlink_L: blinkPulse,
+      eyeBlink_R: blinkPulse,
+      eyeSquint_L: 0.04 + Math.max(0, smile) * 0.18,
+      eyeSquint_R: 0.04 + Math.max(0, smile) * 0.18,
+      jawOpen,
+      mouthSmile_L: smile,
+      mouthSmile_R: smile * 0.95,
+      mouthDimple_L: smile * 0.38,
+      mouthDimple_R: smile * 0.36,
+      mouthClose: 0.04,
+    },
+    headRotation: {
+      pitch: Math.sin(timeSeconds * 0.42) * 0.08,
+      yaw: Math.sin(timeSeconds * 0.36) * 0.18,
+      roll: Math.sin(timeSeconds * 0.31) * 0.04,
+    },
+    gaze: {
+      left: { yaw: gazeYaw, pitch: gazePitch },
+      right: { yaw: gazeYaw, pitch: gazePitch },
+    },
+  };
+}

--- a/src/hooks/useFaceTrackingAdapter.ts
+++ b/src/hooks/useFaceTrackingAdapter.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import {
+  createDemoTrackingFrame,
+  createMouseTrackingFrame,
+  type FaceTrackingAdapterId,
+} from '../features/tracking/adapters';
+import type { FaceTwinTracking } from '../features/tracking/types';
+import { useMediaPipeFaceTwin } from './useMediaPipeFaceTwin';
+
+export type UseFaceTrackingAdapterOptions = {
+  adapterId: FaceTrackingAdapterId;
+  webcamCaptureEnabled: boolean;
+  webcamTrackingEnabled: boolean;
+};
+
+export function useFaceTrackingAdapter({
+  adapterId,
+  webcamCaptureEnabled,
+  webcamTrackingEnabled,
+}: UseFaceTrackingAdapterOptions): FaceTwinTracking {
+  const webcamTracking = useMediaPipeFaceTwin({
+    captureEnabled: webcamCaptureEnabled,
+    trackingEnabled: adapterId === 'webcam' && webcamTrackingEnabled,
+  });
+  const [demoTracking, setDemoTracking] = useState(() => createDemoTrackingFrame(0));
+
+  useEffect(() => {
+    if (adapterId !== 'demo') return;
+
+    let cancelled = false;
+    let rafId = 0;
+
+    const tick = () => {
+      if (cancelled) return;
+      setDemoTracking(createDemoTrackingFrame(performance.now() * 0.001));
+      rafId = requestAnimationFrame(tick);
+    };
+
+    rafId = requestAnimationFrame(tick);
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(rafId);
+    };
+  }, [adapterId]);
+
+  if (adapterId === 'webcam') {
+    return webcamTracking;
+  }
+
+  if (adapterId === 'demo') {
+    return demoTracking;
+  }
+
+  return createMouseTrackingFrame(webcamTracking.videoElement);
+}

--- a/src/routes/MainRoute.tsx
+++ b/src/routes/MainRoute.tsx
@@ -19,7 +19,9 @@ import {
   type LightingMode,
   type PresentationShotId,
 } from '../features/presentation/shots';
-import { type FaceTwinTracking, useMediaPipeFaceTwin } from '../hooks/useMediaPipeFaceTwin';
+import type { FaceTrackingAdapterId } from '../features/tracking/adapters';
+import type { FaceTwinTracking } from '../features/tracking/types';
+import { useFaceTrackingAdapter } from '../hooks/useFaceTrackingAdapter';
 
 function SceneGrade({ screenBrightness, exposure, environmentIntensity }: { screenBrightness: number; exposure: number; environmentIntensity: number }) {
   const { gl, scene } = useThree();
@@ -111,10 +113,12 @@ export default function MainRoute() {
   const [activeShot, setActiveShot] = useState<PresentationShotId>('portrait');
   const [effectsEnabled] = useState(false);
   const compactViewport = useCompactViewport();
+  const trackingAdapterId: FaceTrackingAdapterId = trackingEnabled ? 'webcam' : 'mouse';
 
-  const faceTracking = useMediaPipeFaceTwin({
-    captureEnabled: trackingEnabled || videoEnvEnabled,
-    trackingEnabled,
+  const faceTracking = useFaceTrackingAdapter({
+    adapterId: trackingAdapterId,
+    webcamCaptureEnabled: trackingEnabled || videoEnvEnabled,
+    webcamTrackingEnabled: trackingEnabled,
   });
 
   const { faceScale, viewMode, showCustomEyes, showStats, renderExposure, cubemapIntensity } = useControls({


### PR DESCRIPTION
## Summary
- Add a typed `FaceTrackingAdapterId` contract for mouse, demo, and webcam tracking sources.
- Add mouse/manual and synthetic demo frame factories that produce the same `FaceTwinTracking` shape as webcam tracking.
- Add `useFaceTrackingAdapter` to select between mouse, demo, and MediaPipe webcam adapters.
- Route `MainRoute` through the adapter hook while preserving current visible behavior: manual by default, webcam when Tracking is enabled, webcam capture still available for video reflections.
- Update README project layout to document the adapter boundary.

Closes #6.

## Validation
- `pnpm lint`
- `pnpm build`
- Playwright CLI smoke on `/`: verified default manual adapter render and Mouth shot switch, console reported 0 errors and 0 warnings.