### PR TITLE
[codex] Add procedural head generator lab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import MainRoute from './routes/MainRoute';
 
 const BeautyMaterialLabRoute = lazy(() => import('./routes/BeautyMaterialLabRoute'));
+const ProceduralHeadRoute = lazy(() => import('./routes/ProceduralHeadRoute'));
 const MaterialParityRoute = lazy(() => import('./routes/MaterialParityRoute'));
 const AssetConditioningRoute = lazy(() => import('./routes/AssetConditioningRoute'));
 
@@ -19,6 +20,14 @@ export default function App() {
         element={(
           <Suspense fallback={<RouteFallback label="beauty lab" />}>
             <BeautyMaterialLabRoute />
+          </Suspense>
+        )}
+      />
+      <Route
+        path="/labs/procedural-head"
+        element={(
+          <Suspense fallback={<RouteFallback label="procedural head" />}>
+            <ProceduralHeadRoute />
           </Suspense>
         )}
       />

--- a/src/features/procedural-head/geometry.ts
+++ b/src/features/procedural-head/geometry.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import type {
   ProceduralExpressionName,
+  ProceduralExpressionValues,
   ProceduralHeadIdentity,
   ProceduralHeadQuality,
 } from './types';
@@ -18,6 +19,8 @@ export type ProceduralHeadAnchors = {
 export type ProceduralHeadGeometryBundle = {
   geometry: THREE.BufferGeometry;
   anchors: ProceduralHeadAnchors;
+  basePositions: Float32Array;
+  expressionDeltas: Record<ProceduralExpressionName, Float32Array>;
 };
 
 type VertexMeta = {
@@ -191,6 +194,34 @@ function createExpressionDelta(name: ProceduralExpressionName, point: THREE.Vect
   return delta;
 }
 
+export function applyProceduralHeadExpressions(
+  geometry: THREE.BufferGeometry,
+  basePositions: Float32Array,
+  expressionDeltas: Record<ProceduralExpressionName, Float32Array>,
+  expressions: ProceduralExpressionValues,
+  strength: number,
+) {
+  const position = geometry.getAttribute('position') as THREE.BufferAttribute;
+  const target = position.array as Float32Array;
+  target.set(basePositions);
+
+  for (const name of PROCEDURAL_EXPRESSION_NAMES) {
+    const influence = clamp((expressions[name] ?? 0) * strength);
+    if (influence <= 0) continue;
+
+    const delta = expressionDeltas[name];
+    for (let i = 0; i < target.length; i += 1) {
+      target[i] += delta[i] * influence;
+    }
+  }
+
+  position.needsUpdate = true;
+  geometry.computeVertexNormals();
+  const normal = geometry.getAttribute('normal') as THREE.BufferAttribute | undefined;
+  if (normal) normal.needsUpdate = true;
+  geometry.computeBoundingSphere();
+}
+
 export function createProceduralHeadGeometry(
   identity: ProceduralHeadIdentity,
   quality: ProceduralHeadQuality,
@@ -229,18 +260,19 @@ export function createProceduralHeadGeometry(
     }
   }
 
+  const basePositions = Float32Array.from(positions);
   const geometry = new THREE.BufferGeometry();
-  geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geometry.setAttribute('position', new THREE.BufferAttribute(basePositions.slice(), 3));
   geometry.setAttribute('normal', new THREE.Float32BufferAttribute(normals, 3));
   geometry.setAttribute('uv', new THREE.Float32BufferAttribute(uvs, 2));
   geometry.setIndex(indices);
   geometry.computeVertexNormals();
   geometry.computeBoundingBox();
   geometry.computeBoundingSphere();
-  geometry.morphTargetsRelative = true;
 
   const base = geometry.getAttribute('position') as THREE.BufferAttribute;
-  geometry.morphAttributes.position = PROCEDURAL_EXPRESSION_NAMES.map((name) => {
+  const expressionDeltas = {} as Record<ProceduralExpressionName, Float32Array>;
+  for (const name of PROCEDURAL_EXPRESSION_NAMES) {
     const deltas = new Float32Array(base.count * 3);
     const point = new THREE.Vector3();
     for (let i = 0; i < base.count; i += 1) {
@@ -250,10 +282,8 @@ export function createProceduralHeadGeometry(
       deltas[i * 3 + 1] = delta.y;
       deltas[i * 3 + 2] = delta.z;
     }
-    const attr = new THREE.BufferAttribute(deltas, 3);
-    attr.name = name;
-    return attr;
-  });
+    expressionDeltas[name] = deltas;
+  }
 
   const eyeSpacing = lerp(0.22, 0.34, identity.eyeSpacing);
   const anchors = {
@@ -264,5 +294,5 @@ export function createProceduralHeadGeometry(
     chin: new THREE.Vector3(0, -0.84, 0.42),
   };
 
-  return { geometry, anchors };
+  return { geometry, anchors, basePositions, expressionDeltas };
 }

--- a/src/features/procedural-head/geometry.ts
+++ b/src/features/procedural-head/geometry.ts
@@ -1,0 +1,268 @@
+import * as THREE from 'three';
+import type {
+  ProceduralExpressionName,
+  ProceduralHeadIdentity,
+  ProceduralHeadQuality,
+} from './types';
+import { PROCEDURAL_EXPRESSION_NAMES, PROCEDURAL_QUALITY_CONFIG } from './types';
+import { clamp, gaussian2D, lerp, smoothstep } from './random';
+
+export type ProceduralHeadAnchors = {
+  leftEye: THREE.Vector3;
+  rightEye: THREE.Vector3;
+  mouth: THREE.Vector3;
+  noseTip: THREE.Vector3;
+  chin: THREE.Vector3;
+};
+
+export type ProceduralHeadGeometryBundle = {
+  geometry: THREE.BufferGeometry;
+  anchors: ProceduralHeadAnchors;
+};
+
+type VertexMeta = {
+  theta: number;
+  yNorm: number;
+};
+
+function sideMask(x: number, side: 'L' | 'R') {
+  return side === 'L' ? smoothstep(0.04, -0.32, x) : smoothstep(-0.04, 0.32, x);
+}
+
+function frontMask(theta: number) {
+  return smoothstep(0.05, 0.86, Math.cos(theta));
+}
+
+function createHeadPoint(theta: number, yNorm: number, identity: ProceduralHeadIdentity) {
+  const faceWidth = lerp(0.82, 1.12, identity.faceWidth);
+  const skullHeight = lerp(0.92, 1.18, identity.skullHeight);
+  const jawWidth = lerp(0.55, 1.0, identity.jawWidth);
+  const cheekbone = lerp(0.88, 1.2, identity.cheekbone);
+  const browRidge = lerp(0.02, 0.09, identity.browRidge);
+  const noseProjection = lerp(0.08, 0.26, identity.noseProjection);
+  const noseWidth = lerp(0.7, 1.25, identity.noseWidth);
+
+  const verticalRadius = Math.sqrt(Math.max(0.018, 1 - Math.pow(yNorm * 0.92, 2)));
+  const jawT = smoothstep(-0.38, -0.92, yNorm);
+  const crownT = smoothstep(0.38, 0.94, yNorm);
+  const templeT = smoothstep(0.05, 0.42, yNorm) * (1 - crownT * 0.35);
+  const cheekT = gaussian2D(0, yNorm, 0, -0.08, 1, 0.24);
+
+  let width = lerp(0.26, 0.74, verticalRadius) * faceWidth;
+  width *= lerp(1, jawWidth, jawT);
+  width *= lerp(1, 0.78, crownT);
+  width *= lerp(1, cheekbone, cheekT * 0.38);
+  width *= lerp(1, 0.88, templeT * 0.22);
+
+  let depth = lerp(0.28, 0.58, verticalRadius) * lerp(0.92, 1.08, identity.faceWidth);
+  depth *= lerp(1, 0.72, jawT * 0.45);
+  depth *= lerp(1, 1.12, crownT * 0.25);
+
+  let y = yNorm * 1.08 * skullHeight;
+  let x = Math.sin(theta) * width;
+  let z = Math.cos(theta) * depth;
+
+  const front = frontMask(theta);
+  const centerFront = Math.exp(-Math.pow(theta / 0.42, 2));
+  const noseBridge = centerFront * gaussian2D(0, yNorm, 0, 0.18, 1, 0.32);
+  const noseTip = centerFront * gaussian2D(0, yNorm, 0, -0.02, 1, 0.16);
+  const nostril = centerFront * gaussian2D(0, yNorm, 0, -0.16, 1, 0.08);
+  const mouthInset = centerFront * gaussian2D(0, yNorm, 0, -0.43, 1, 0.12);
+  const chin = centerFront * gaussian2D(0, yNorm, 0, -0.72, 1, 0.18);
+  const brow = front * gaussian2D(0, yNorm, 0, 0.33, 1, 0.08);
+
+  z += noseBridge * noseProjection * 0.48;
+  z += noseTip * noseProjection;
+  z += nostril * noseProjection * 0.28;
+  z -= mouthInset * lerp(0.025, 0.07, identity.lipFullness);
+  z += chin * 0.05;
+  z += brow * browRidge;
+
+  const eyeX = lerp(0.22, 0.34, identity.eyeSpacing);
+  const eyeY = 0.23;
+  const eyeWidth = lerp(0.12, 0.18, identity.eyeScale);
+  const leftSocket = gaussian2D(x, yNorm, -eyeX, eyeY, eyeWidth, 0.12) * front;
+  const rightSocket = gaussian2D(x, yNorm, eyeX, eyeY, eyeWidth, 0.12) * front;
+  const socket = leftSocket + rightSocket;
+  z -= socket * lerp(0.07, 0.15, identity.browRidge);
+  y += socket * -0.018;
+
+  const noseNarrow = centerFront * gaussian2D(0, yNorm, 0, 0, 1, 0.28);
+  x *= 1 - noseNarrow * lerp(0.08, 0.24, noseWidth);
+
+  return new THREE.Vector3(x, y, z);
+}
+
+function createExpressionDelta(name: ProceduralExpressionName, point: THREE.Vector3, meta: VertexMeta) {
+  const delta = new THREE.Vector3();
+  const front = frontMask(meta.theta);
+  const mouthCore = gaussian2D(point.x, meta.yNorm, 0, -0.43, 0.38, 0.17) * front;
+  const lowerFace = smoothstep(-0.2, -0.86, meta.yNorm) * front;
+  const browCore = gaussian2D(point.x, meta.yNorm, 0, 0.34, 0.55, 0.11) * front;
+  const cheekL = gaussian2D(point.x, meta.yNorm, -0.28, -0.12, 0.22, 0.18) * front;
+  const cheekR = gaussian2D(point.x, meta.yNorm, 0.28, -0.12, 0.22, 0.18) * front;
+  const eyeL = gaussian2D(point.x, meta.yNorm, -0.28, 0.23, 0.18, 0.12) * front;
+  const eyeR = gaussian2D(point.x, meta.yNorm, 0.28, 0.23, 0.18, 0.12) * front;
+  const noseL = gaussian2D(point.x, meta.yNorm, -0.11, -0.04, 0.12, 0.2) * front;
+  const noseR = gaussian2D(point.x, meta.yNorm, 0.11, -0.04, 0.12, 0.2) * front;
+  const lipBand = gaussian2D(point.x, meta.yNorm, 0, -0.42, 0.34, 0.07) * front;
+  const sideL = sideMask(point.x, 'L');
+  const sideR = sideMask(point.x, 'R');
+
+  switch (name) {
+    case 'browInnerUp':
+      delta.y += browCore * 0.065 * (1 - Math.min(Math.abs(point.x) / 0.35, 1) * 0.35);
+      delta.z += browCore * 0.015;
+      break;
+    case 'browOuterUp_L':
+      delta.y += browCore * sideL * 0.055;
+      delta.z += browCore * sideL * 0.01;
+      break;
+    case 'browOuterUp_R':
+      delta.y += browCore * sideR * 0.055;
+      delta.z += browCore * sideR * 0.01;
+      break;
+    case 'eyeBlink_L':
+      delta.y -= eyeL * 0.032;
+      delta.z -= eyeL * 0.018;
+      break;
+    case 'eyeBlink_R':
+      delta.y -= eyeR * 0.032;
+      delta.z -= eyeR * 0.018;
+      break;
+    case 'eyeSquint_L':
+      delta.y -= eyeL * 0.016;
+      delta.z += eyeL * 0.01;
+      break;
+    case 'eyeSquint_R':
+      delta.y -= eyeR * 0.016;
+      delta.z += eyeR * 0.01;
+      break;
+    case 'cheekSquint_L':
+      delta.y += cheekL * 0.055;
+      delta.z += cheekL * 0.035;
+      break;
+    case 'cheekSquint_R':
+      delta.y += cheekR * 0.055;
+      delta.z += cheekR * 0.035;
+      break;
+    case 'jawOpen':
+      delta.y -= lowerFace * 0.13;
+      delta.z -= lowerFace * 0.045;
+      break;
+    case 'mouthSmile_L':
+      delta.x -= mouthCore * sideL * 0.075;
+      delta.y += mouthCore * sideL * 0.08;
+      delta.z += mouthCore * sideL * 0.018;
+      break;
+    case 'mouthSmile_R':
+      delta.x += mouthCore * sideR * 0.075;
+      delta.y += mouthCore * sideR * 0.08;
+      delta.z += mouthCore * sideR * 0.018;
+      break;
+    case 'mouthFunnel':
+      delta.z += lipBand * 0.06;
+      delta.x *= 0.5;
+      break;
+    case 'mouthPucker':
+      delta.z += lipBand * 0.09;
+      delta.x -= point.x * lipBand * 0.16;
+      break;
+    case 'mouthPress_L':
+      delta.y -= lipBand * sideL * 0.02;
+      delta.z -= lipBand * sideL * 0.025;
+      break;
+    case 'mouthPress_R':
+      delta.y -= lipBand * sideR * 0.02;
+      delta.z -= lipBand * sideR * 0.025;
+      break;
+    case 'noseSneer_L':
+      delta.y += noseL * 0.045;
+      delta.z += noseL * 0.022;
+      break;
+    case 'noseSneer_R':
+      delta.y += noseR * 0.045;
+      delta.z += noseR * 0.022;
+      break;
+    default:
+      break;
+  }
+
+  return delta;
+}
+
+export function createProceduralHeadGeometry(
+  identity: ProceduralHeadIdentity,
+  quality: ProceduralHeadQuality,
+): ProceduralHeadGeometryBundle {
+  const config = PROCEDURAL_QUALITY_CONFIG[quality];
+  const positions: number[] = [];
+  const normals: number[] = [];
+  const uvs: number[] = [];
+  const indices: number[] = [];
+  const meta: VertexMeta[] = [];
+  const radialSegments = config.radialSegments;
+  const verticalSegments = config.verticalSegments;
+
+  for (let iy = 0; iy <= verticalSegments; iy += 1) {
+    const v = iy / verticalSegments;
+    const yNorm = 1 - v * 2;
+    for (let ix = 0; ix <= radialSegments; ix += 1) {
+      const u = ix / radialSegments;
+      const theta = u * Math.PI * 2;
+      const point = createHeadPoint(theta, yNorm, identity);
+      positions.push(point.x, point.y, point.z);
+      normals.push(0, 0, 1);
+      uvs.push(u, v);
+      meta.push({ theta, yNorm });
+    }
+  }
+
+  const stride = radialSegments + 1;
+  for (let iy = 0; iy < verticalSegments; iy += 1) {
+    for (let ix = 0; ix < radialSegments; ix += 1) {
+      const a = iy * stride + ix;
+      const b = a + stride;
+      const c = b + 1;
+      const d = a + 1;
+      indices.push(a, b, d, b, c, d);
+    }
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geometry.setAttribute('normal', new THREE.Float32BufferAttribute(normals, 3));
+  geometry.setAttribute('uv', new THREE.Float32BufferAttribute(uvs, 2));
+  geometry.setIndex(indices);
+  geometry.computeVertexNormals();
+  geometry.computeBoundingBox();
+  geometry.computeBoundingSphere();
+  geometry.morphTargetsRelative = true;
+
+  const base = geometry.getAttribute('position') as THREE.BufferAttribute;
+  geometry.morphAttributes.position = PROCEDURAL_EXPRESSION_NAMES.map((name) => {
+    const deltas = new Float32Array(base.count * 3);
+    const point = new THREE.Vector3();
+    for (let i = 0; i < base.count; i += 1) {
+      point.fromBufferAttribute(base, i);
+      const delta = createExpressionDelta(name, point, meta[i]);
+      deltas[i * 3] = delta.x;
+      deltas[i * 3 + 1] = delta.y;
+      deltas[i * 3 + 2] = delta.z;
+    }
+    const attr = new THREE.BufferAttribute(deltas, 3);
+    attr.name = name;
+    return attr;
+  });
+
+  const eyeSpacing = lerp(0.22, 0.34, identity.eyeSpacing);
+  const anchors = {
+    leftEye: new THREE.Vector3(-eyeSpacing, 0.25, 0.54),
+    rightEye: new THREE.Vector3(eyeSpacing, 0.25, 0.54),
+    mouth: new THREE.Vector3(0, -0.46, 0.6),
+    noseTip: new THREE.Vector3(0, -0.02, 0.72 + clamp(identity.noseProjection) * 0.08),
+    chin: new THREE.Vector3(0, -0.84, 0.42),
+  };
+
+  return { geometry, anchors };
+}

--- a/src/features/procedural-head/maps.ts
+++ b/src/features/procedural-head/maps.ts
@@ -1,0 +1,194 @@
+import * as THREE from 'three';
+import type { ProceduralHeadIdentity, ProceduralHeadQuality } from './types';
+import { PROCEDURAL_QUALITY_CONFIG } from './types';
+import { clamp, fbm2D, gaussian2D, hashString, lerp, smoothstep, valueNoise2D } from './random';
+
+export type ProceduralSkinTexturePack = {
+  albedoMap: THREE.CanvasTexture;
+  normalMap: THREE.CanvasTexture;
+  roughnessMap: THREE.CanvasTexture;
+  regionMap: THREE.CanvasTexture;
+  resolution: number;
+  dispose: () => void;
+};
+
+function makeCanvas(size: number) {
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  return canvas;
+}
+
+function makeTexture(canvas: HTMLCanvasElement, colorSpace: THREE.ColorSpace) {
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = colorSpace;
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.ClampToEdgeWrapping;
+  texture.minFilter = THREE.LinearMipmapLinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  texture.generateMipmaps = true;
+  texture.anisotropy = 4;
+  texture.needsUpdate = true;
+  return texture;
+}
+
+function writePixel(data: Uint8ClampedArray, index: number, r: number, g: number, b: number, a = 255) {
+  data[index] = clamp(r, 0, 255);
+  data[index + 1] = clamp(g, 0, 255);
+  data[index + 2] = clamp(b, 0, 255);
+  data[index + 3] = clamp(a, 0, 255);
+}
+
+function skinRegionMasks(u: number, v: number) {
+  const x = u * 2 - 1;
+  const y = v * 2 - 1;
+  const center = 1 - Math.min(Math.abs(x), 1);
+  const forehead = gaussian2D(x, y, 0, -0.48, 0.74, 0.28) * center;
+  const nose = gaussian2D(x, y, 0, -0.08, 0.18, 0.34) * center;
+  const cheekL = gaussian2D(x, y, -0.42, 0.04, 0.32, 0.26);
+  const cheekR = gaussian2D(x, y, 0.42, 0.04, 0.32, 0.26);
+  const underEye = gaussian2D(x, y, -0.34, -0.25, 0.24, 0.08) + gaussian2D(x, y, 0.34, -0.25, 0.24, 0.08);
+  const mouth = gaussian2D(x, y, 0, 0.42, 0.44, 0.13) * center;
+  const chin = gaussian2D(x, y, 0, 0.72, 0.42, 0.2) * center;
+  const sebum = clamp(nose * 0.9 + forehead * 0.45 + chin * 0.22, 0, 1);
+
+  return {
+    forehead,
+    nose,
+    cheeks: clamp(cheekL + cheekR, 0, 1),
+    underEye: clamp(underEye, 0, 1),
+    mouth,
+    chin,
+    sebum,
+  };
+}
+
+export function createProceduralSkinTexturePack(
+  identity: ProceduralHeadIdentity,
+  quality: ProceduralHeadQuality,
+): ProceduralSkinTexturePack {
+  const resolution = PROCEDURAL_QUALITY_CONFIG[quality].mapResolution;
+  const seed = hashString(identity.seed);
+  const albedoCanvas = makeCanvas(resolution);
+  const roughnessCanvas = makeCanvas(resolution);
+  const normalCanvas = makeCanvas(resolution);
+  const regionCanvas = makeCanvas(resolution);
+
+  const albedoCtx = albedoCanvas.getContext('2d');
+  const roughnessCtx = roughnessCanvas.getContext('2d');
+  const normalCtx = normalCanvas.getContext('2d');
+  const regionCtx = regionCanvas.getContext('2d');
+
+  if (!albedoCtx || !roughnessCtx || !normalCtx || !regionCtx) {
+    throw new Error('Unable to create procedural skin map contexts.');
+  }
+
+  const albedoImage = albedoCtx.createImageData(resolution, resolution);
+  const roughnessImage = roughnessCtx.createImageData(resolution, resolution);
+  const regionImage = regionCtx.createImageData(resolution, resolution);
+  const height = new Float32Array(resolution * resolution);
+
+  const melanin = clamp(identity.melanin);
+  const hemoglobin = clamp(identity.hemoglobin);
+  const oiliness = clamp(identity.oiliness);
+  const age = clamp(identity.age);
+  const poreScale = lerp(0.75, 1.45, identity.poreScale);
+
+  for (let y = 0; y < resolution; y += 1) {
+    const v = y / (resolution - 1);
+    for (let x = 0; x < resolution; x += 1) {
+      const u = x / (resolution - 1);
+      const index = (y * resolution + x) * 4;
+      const fieldIndex = y * resolution + x;
+      const masks = skinRegionMasks(u, v);
+      const faceX = u * 2 - 1;
+      const faceY = v * 2 - 1;
+
+      const macro = fbm2D(u * 4.2, v * 5.6, seed, 4) - 0.5;
+      const mottle = fbm2D(u * 16, v * 21, seed + 72, 3) - 0.5;
+      const pore = valueNoise2D(u * 170 * poreScale, v * 210 * poreScale, seed + 173);
+      const poreRim = smoothstep(0.48, 0.78, pore) - smoothstep(0.78, 0.94, pore);
+      const wrinkle = fbm2D(u * 46, v * 20, seed + 991, 3) - 0.5;
+      const foreheadLines = masks.forehead * Math.pow(Math.sin((faceY + 0.5) * 52 + macro * 3) * 0.5 + 0.5, 12) * age;
+      const crow = masks.underEye * Math.pow(Math.sin((Math.abs(faceX) - 0.24) * 62 + faceY * 24) * 0.5 + 0.5, 10) * age;
+
+      const baseR = lerp(224, 118, melanin);
+      const baseG = lerp(174, 88, melanin);
+      const baseB = lerp(142, 62, melanin);
+      const redness = hemoglobin * (masks.cheeks * 0.42 + masks.nose * 0.24 + masks.underEye * 0.12 + masks.mouth * 0.18);
+      const yellow = melanin * 18 - hemoglobin * 5;
+      const coolUnderEye = masks.underEye * lerp(5, 18, age);
+      const freckleNoise = valueNoise2D(u * 72, v * 87, seed + 337);
+      const freckle = smoothstep(0.79, 0.93, freckleNoise) * melanin * (1 - masks.mouth) * 0.72;
+
+      const r = baseR + redness * 42 + macro * 16 + mottle * 10 - freckle * 58;
+      const g = baseG - redness * 10 + yellow + macro * 11 + mottle * 7 - freckle * 42 - coolUnderEye;
+      const b = baseB - redness * 18 + macro * 8 + mottle * 6 - freckle * 26 + coolUnderEye;
+      writePixel(albedoImage.data, index, r, g, b);
+
+      const roughness = clamp(
+        0.58
+        - masks.sebum * lerp(0.12, 0.24, oiliness)
+        + masks.cheeks * 0.035
+        + age * 0.05
+        + poreRim * 0.06
+        + mottle * 0.03,
+        0.24,
+        0.88,
+      );
+      writePixel(roughnessImage.data, index, roughness * 255, roughness * 255, roughness * 255);
+
+      height[fieldIndex] =
+        macro * 0.018
+        + poreRim * 0.025
+        - smoothstep(0.12, 0.38, pore) * 0.018 * identity.poreScale
+        - foreheadLines * 0.04
+        - crow * 0.032
+        + wrinkle * 0.01 * age;
+
+      const regionR = clamp(masks.cheeks + masks.mouth * 0.5, 0, 1);
+      const regionG = clamp(masks.nose + masks.sebum * 0.5, 0, 1);
+      const regionB = clamp(masks.forehead + masks.underEye * 0.8 + masks.chin * 0.3, 0, 1);
+      writePixel(regionImage.data, index, regionR * 255, regionG * 255, regionB * 255);
+    }
+  }
+
+  const normalImage = normalCtx.createImageData(resolution, resolution);
+  const normalStrength = quality === 'hero' ? 7.5 : quality === 'balanced' ? 5.25 : 3.4;
+  for (let y = 0; y < resolution; y += 1) {
+    for (let x = 0; x < resolution; x += 1) {
+      const left = height[y * resolution + Math.max(0, x - 1)];
+      const right = height[y * resolution + Math.min(resolution - 1, x + 1)];
+      const up = height[Math.max(0, y - 1) * resolution + x];
+      const down = height[Math.min(resolution - 1, y + 1) * resolution + x];
+      const dx = (right - left) * normalStrength;
+      const dy = (down - up) * normalStrength;
+      const nz = 1 / Math.sqrt(dx * dx + dy * dy + 1);
+      const nx = -dx * nz;
+      const ny = -dy * nz;
+      const index = (y * resolution + x) * 4;
+      writePixel(normalImage.data, index, (nx * 0.5 + 0.5) * 255, (ny * 0.5 + 0.5) * 255, (nz * 0.5 + 0.5) * 255);
+    }
+  }
+
+  albedoCtx.putImageData(albedoImage, 0, 0);
+  roughnessCtx.putImageData(roughnessImage, 0, 0);
+  normalCtx.putImageData(normalImage, 0, 0);
+  regionCtx.putImageData(regionImage, 0, 0);
+
+  const pack: ProceduralSkinTexturePack = {
+    albedoMap: makeTexture(albedoCanvas, THREE.SRGBColorSpace),
+    roughnessMap: makeTexture(roughnessCanvas, THREE.NoColorSpace),
+    normalMap: makeTexture(normalCanvas, THREE.NoColorSpace),
+    regionMap: makeTexture(regionCanvas, THREE.SRGBColorSpace),
+    resolution,
+    dispose: () => {
+      pack.albedoMap.dispose();
+      pack.roughnessMap.dispose();
+      pack.normalMap.dispose();
+      pack.regionMap.dispose();
+    },
+  };
+
+  return pack;
+}

--- a/src/features/procedural-head/materials.tsx
+++ b/src/features/procedural-head/materials.tsx
@@ -1,0 +1,135 @@
+import * as THREE from 'three';
+import type { ProceduralHeadMaterialMode, ProceduralHeadQuality } from './types';
+import type { ProceduralSkinTexturePack } from './maps';
+
+export function ProceduralBeautyMaterial({
+  mode,
+  quality,
+  textures,
+}: {
+  mode: ProceduralHeadMaterialMode;
+  quality: ProceduralHeadQuality;
+  textures: ProceduralSkinTexturePack;
+}) {
+  const isTopology = mode === 'topology';
+  const isMaps = mode === 'maps';
+
+  return (
+    <meshPhysicalMaterial
+      map={isMaps ? textures.regionMap : textures.albedoMap}
+      normalMap={isTopology ? null : textures.normalMap}
+      roughnessMap={isTopology ? null : textures.roughnessMap}
+      normalScale={new THREE.Vector2(quality === 'hero' ? 0.72 : quality === 'balanced' ? 0.52 : 0.32)}
+      color={isTopology ? '#cab4a7' : '#ffffff'}
+      wireframe={isTopology}
+      roughness={isTopology ? 0.72 : 0.48}
+      metalness={0}
+      envMapIntensity={isTopology ? 0.55 : 1.1}
+      clearcoat={isTopology ? 0 : 0.16}
+      clearcoatRoughness={0.62}
+      sheen={isTopology ? 0 : 0.28}
+      sheenRoughness={0.78}
+      sheenColor={new THREE.Color('#ffd2bf')}
+      specularIntensity={isTopology ? 0.35 : 0.86}
+      specularColor={new THREE.Color('#fff0e6')}
+    />
+  );
+}
+
+export function ProceduralLipMaterial({ mode }: { mode: ProceduralHeadMaterialMode }) {
+  return (
+    <meshPhysicalMaterial
+      color={mode === 'maps' ? '#f04a84' : '#a55357'}
+      roughness={0.42}
+      metalness={0}
+      envMapIntensity={0.9}
+      clearcoat={0.18}
+      clearcoatRoughness={0.5}
+      specularIntensity={0.72}
+      wireframe={mode === 'topology'}
+    />
+  );
+}
+
+export function ProceduralGumMaterial({ mode }: { mode: ProceduralHeadMaterialMode }) {
+  return (
+    <meshPhysicalMaterial
+      color={mode === 'maps' ? '#d84d69' : '#8c3b45'}
+      roughness={0.58}
+      metalness={0}
+      clearcoat={0.08}
+      clearcoatRoughness={0.54}
+      envMapIntensity={0.45}
+      wireframe={mode === 'topology'}
+    />
+  );
+}
+
+export function ProceduralDentalMaterial({ mode }: { mode: ProceduralHeadMaterialMode }) {
+  return (
+    <meshPhysicalMaterial
+      color={mode === 'maps' ? '#fff6d8' : '#e8dfc8'}
+      roughness={0.34}
+      metalness={0}
+      clearcoat={0.28}
+      clearcoatRoughness={0.25}
+      envMapIntensity={0.72}
+      specularIntensity={0.65}
+      wireframe={mode === 'topology'}
+    />
+  );
+}
+
+export function ProceduralTongueMaterial({ mode }: { mode: ProceduralHeadMaterialMode }) {
+  return (
+    <meshPhysicalMaterial
+      color={mode === 'maps' ? '#e75f75' : '#904252'}
+      roughness={0.5}
+      metalness={0}
+      clearcoat={0.15}
+      clearcoatRoughness={0.38}
+      envMapIntensity={0.42}
+      wireframe={mode === 'topology'}
+    />
+  );
+}
+
+export function ProceduralEyeMaterials({ mode }: { mode: ProceduralHeadMaterialMode }) {
+  return {
+    sclera: (
+      <meshPhysicalMaterial
+        color={mode === 'maps' ? '#e5f3ff' : '#e7dfd4'}
+        roughness={0.28}
+        metalness={0}
+        clearcoat={0.35}
+        clearcoatRoughness={0.22}
+        envMapIntensity={0.85}
+        wireframe={mode === 'topology'}
+      />
+    ),
+    iris: (
+      <meshPhysicalMaterial
+        color={mode === 'maps' ? '#46a7d8' : '#4d8a76'}
+        roughness={0.36}
+        metalness={0}
+        clearcoat={0.18}
+        envMapIntensity={0.75}
+        wireframe={mode === 'topology'}
+      />
+    ),
+    pupil: <meshBasicMaterial color="#070707" wireframe={mode === 'topology'} />,
+    cornea: (
+      <meshPhysicalMaterial
+        color="#ffffff"
+        transparent
+        opacity={mode === 'topology' ? 0.12 : 0.22}
+        roughness={0.02}
+        metalness={0}
+        transmission={0.35}
+        thickness={0.08}
+        envMapIntensity={1.4}
+        wireframe={mode === 'topology'}
+      />
+    ),
+  };
+}

--- a/src/features/procedural-head/materials.tsx
+++ b/src/features/procedural-head/materials.tsx
@@ -125,9 +125,11 @@ export function ProceduralEyeMaterials({ mode }: { mode: ProceduralHeadMaterialM
         opacity={mode === 'topology' ? 0.12 : 0.22}
         roughness={0.02}
         metalness={0}
-        transmission={0.35}
-        thickness={0.08}
         envMapIntensity={1.4}
+        depthWrite={false}
+        clearcoat={1}
+        clearcoatRoughness={0.04}
+        specularIntensity={1}
         wireframe={mode === 'topology'}
       />
     ),

--- a/src/features/procedural-head/mouthSystem.tsx
+++ b/src/features/procedural-head/mouthSystem.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useMemo, useRef } from 'react';
+import * as THREE from 'three';
+import type {
+  ProceduralExpressionValues,
+  ProceduralHeadIdentity,
+  ProceduralHeadMaterialMode,
+  ProceduralHeadQuality,
+} from './types';
+import { PROCEDURAL_QUALITY_CONFIG } from './types';
+import {
+  ProceduralDentalMaterial,
+  ProceduralGumMaterial,
+  ProceduralLipMaterial,
+  ProceduralTongueMaterial,
+} from './materials';
+import { clamp, gaussian2D, lerp, smoothstep } from './random';
+
+function setMorphInfluences(mesh: THREE.Mesh | null, expressions: ProceduralExpressionValues, strength: number) {
+  if (!mesh?.morphTargetDictionary || !mesh.morphTargetInfluences) return;
+  for (const [name, index] of Object.entries(mesh.morphTargetDictionary)) {
+    mesh.morphTargetInfluences[index] = clamp((expressions[name as keyof ProceduralExpressionValues] ?? 0) * strength);
+  }
+}
+
+function createLipPoint(t: number, row: number, identity: ProceduralHeadIdentity) {
+  const lipWidth = lerp(0.32, 0.48, identity.faceWidth);
+  const lipHeight = lerp(0.052, 0.11, identity.lipFullness);
+  const thickness = lerp(0.014, 0.045, identity.lipFullness);
+  const x = Math.cos(t) * lipWidth * (1 + Math.sin(t) * 0.05);
+  const y = -0.43 + Math.sin(t) * lipHeight + row * thickness;
+  const z = 0.626 + Math.cos(t) * 0.018 + Math.abs(Math.sin(t)) * thickness * 0.55;
+  return new THREE.Vector3(x, y, z);
+}
+
+export function createProceduralLipGeometry(identity: ProceduralHeadIdentity, quality: ProceduralHeadQuality) {
+  const config = PROCEDURAL_QUALITY_CONFIG[quality];
+  const segments = Math.max(48, Math.round(config.radialSegments * 0.75));
+  const rows = quality === 'hero' ? 7 : quality === 'balanced' ? 5 : 4;
+  const positions: number[] = [];
+  const normals: number[] = [];
+  const uvs: number[] = [];
+  const indices: number[] = [];
+
+  for (let row = 0; row <= rows; row += 1) {
+    const rowT = row / rows;
+    const rowOffset = (rowT - 0.5) * 2;
+    for (let i = 0; i <= segments; i += 1) {
+      const t = (i / segments) * Math.PI * 2;
+      const p = createLipPoint(t, rowOffset, identity);
+      positions.push(p.x, p.y, p.z);
+      normals.push(0, 0, 1);
+      uvs.push(i / segments, rowT);
+    }
+  }
+
+  const stride = segments + 1;
+  for (let row = 0; row < rows; row += 1) {
+    for (let i = 0; i < segments; i += 1) {
+      const a = row * stride + i;
+      const b = a + stride;
+      const c = b + 1;
+      const d = a + 1;
+      indices.push(a, b, d, b, c, d);
+    }
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geometry.setAttribute('normal', new THREE.Float32BufferAttribute(normals, 3));
+  geometry.setAttribute('uv', new THREE.Float32BufferAttribute(uvs, 2));
+  geometry.setIndex(indices);
+  geometry.computeVertexNormals();
+  geometry.computeBoundingSphere();
+  geometry.morphTargetsRelative = true;
+
+  const base = geometry.getAttribute('position') as THREE.BufferAttribute;
+  const morphNames = ['jawOpen', 'mouthSmile_L', 'mouthSmile_R', 'mouthFunnel', 'mouthPucker', 'mouthPress_L', 'mouthPress_R'];
+  geometry.morphAttributes.position = morphNames.map((name) => {
+    const deltas = new Float32Array(base.count * 3);
+    const point = new THREE.Vector3();
+    for (let i = 0; i < base.count; i += 1) {
+      point.fromBufferAttribute(base, i);
+      const mouth = gaussian2D(point.x, point.y, 0, -0.43, 0.5, 0.12);
+      const left = smoothstep(0.04, -0.3, point.x);
+      const right = smoothstep(-0.04, 0.3, point.x);
+      const delta = new THREE.Vector3();
+      if (name === 'jawOpen') {
+        delta.y -= mouth * smoothstep(-0.39, -0.53, point.y) * 0.16;
+        delta.z -= mouth * 0.035;
+      } else if (name === 'mouthSmile_L') {
+        delta.x -= mouth * left * 0.08;
+        delta.y += mouth * left * 0.09;
+      } else if (name === 'mouthSmile_R') {
+        delta.x += mouth * right * 0.08;
+        delta.y += mouth * right * 0.09;
+      } else if (name === 'mouthFunnel') {
+        delta.z += mouth * 0.085;
+        delta.x -= point.x * mouth * 0.13;
+      } else if (name === 'mouthPucker') {
+        delta.z += mouth * 0.12;
+        delta.x -= point.x * mouth * 0.2;
+      } else if (name === 'mouthPress_L') {
+        delta.y -= mouth * left * 0.026;
+        delta.z -= mouth * left * 0.02;
+      } else if (name === 'mouthPress_R') {
+        delta.y -= mouth * right * 0.026;
+        delta.z -= mouth * right * 0.02;
+      }
+      deltas[i * 3] = delta.x;
+      deltas[i * 3 + 1] = delta.y;
+      deltas[i * 3 + 2] = delta.z;
+    }
+    const attr = new THREE.BufferAttribute(deltas, 3);
+    attr.name = name;
+    return attr;
+  });
+
+  return geometry;
+}
+
+function Tooth({
+  index,
+  total,
+  upper,
+  mode,
+}: {
+  index: number;
+  total: number;
+  upper: boolean;
+  mode: ProceduralHeadMaterialMode;
+}) {
+  const centered = index - (total - 1) / 2;
+  const x = centered * 0.048;
+  const scale = 1 - Math.min(Math.abs(centered) * 0.06, 0.22);
+  const y = upper ? -0.405 : -0.515;
+  const z = 0.665 - Math.abs(centered) * 0.003;
+  return (
+    <mesh position={[x, y, z]} rotation={[upper ? 0.08 : -0.08, 0, centered * -0.015]} scale={[scale, scale, scale]}>
+      <capsuleGeometry args={[0.019, 0.052, 4, 9]} />
+      <ProceduralDentalMaterial mode={mode} />
+    </mesh>
+  );
+}
+export function ProceduralMouthSystem({
+  expressions,
+  identity,
+  mode,
+  quality,
+  strength,
+}: {
+  expressions: ProceduralExpressionValues;
+  identity: ProceduralHeadIdentity;
+  mode: ProceduralHeadMaterialMode;
+  quality: ProceduralHeadQuality;
+  strength: number;
+}) {
+  const lipsRef = useRef<THREE.Mesh>(null);
+  const lowerMouthRef = useRef<THREE.Group>(null);
+  const lipGeometry = useMemo(() => createProceduralLipGeometry(identity, quality), [identity, quality]);
+  const jawOpen = clamp((expressions.jawOpen ?? 0) * strength);
+
+  useEffect(() => () => lipGeometry.dispose(), [lipGeometry]);
+
+  useEffect(() => {
+    setMorphInfluences(lipsRef.current, expressions, strength);
+    if (lowerMouthRef.current) {
+      lowerMouthRef.current.position.y = -jawOpen * 0.105;
+      lowerMouthRef.current.position.z = -jawOpen * 0.026;
+      lowerMouthRef.current.rotation.x = jawOpen * -0.08;
+    }
+  }, [expressions, jawOpen, strength]);
+
+  return (
+    <group>
+      <mesh ref={lipsRef} geometry={lipGeometry}>
+        <ProceduralLipMaterial mode={mode} />
+      </mesh>
+
+      <mesh position={[0, -0.385, 0.645]} scale={[1, 1, 1]}>
+        <boxGeometry args={[0.46, 0.048, 0.062]} />
+        <ProceduralGumMaterial mode={mode} />
+      </mesh>
+      {Array.from({ length: 8 }, (_, index) => (
+        <Tooth key={`upper-${index}`} index={index} total={8} upper mode={mode} />
+      ))}
+
+      <group ref={lowerMouthRef}>
+        <mesh position={[0, -0.535, 0.645]}>
+          <boxGeometry args={[0.42, 0.048, 0.058]} />
+          <ProceduralGumMaterial mode={mode} />
+        </mesh>
+        {Array.from({ length: 8 }, (_, index) => (
+          <Tooth key={`lower-${index}`} index={index} total={8} upper={false} mode={mode} />
+        ))}
+        <mesh position={[0, -0.57, 0.61]} scale={[1.15, 0.22, 0.5]} rotation={[-0.12, 0, 0]}>
+          <sphereGeometry args={[0.16, 32, 14]} />
+          <ProceduralTongueMaterial mode={mode} />
+        </mesh>
+      </group>
+    </group>
+  );
+}

--- a/src/features/procedural-head/mouthSystem.tsx
+++ b/src/features/procedural-head/mouthSystem.tsx
@@ -1,6 +1,8 @@
+import { useThree } from '@react-three/fiber';
 import { useEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
 import type {
+  ProceduralExpressionName,
   ProceduralExpressionValues,
   ProceduralHeadIdentity,
   ProceduralHeadMaterialMode,
@@ -15,12 +17,30 @@ import {
 } from './materials';
 import { clamp, gaussian2D, lerp, smoothstep } from './random';
 
-function setMorphInfluences(mesh: THREE.Mesh | null, expressions: ProceduralExpressionValues, strength: number) {
-  if (!mesh?.morphTargetDictionary || !mesh.morphTargetInfluences) return;
-  for (const [name, index] of Object.entries(mesh.morphTargetDictionary)) {
-    mesh.morphTargetInfluences[index] = clamp((expressions[name as keyof ProceduralExpressionValues] ?? 0) * strength);
-  }
-}
+type LipExpressionName =
+  | 'jawOpen'
+  | 'mouthSmile_L'
+  | 'mouthSmile_R'
+  | 'mouthFunnel'
+  | 'mouthPucker'
+  | 'mouthPress_L'
+  | 'mouthPress_R';
+
+const LIP_EXPRESSION_NAMES: LipExpressionName[] = [
+  'jawOpen',
+  'mouthSmile_L',
+  'mouthSmile_R',
+  'mouthFunnel',
+  'mouthPucker',
+  'mouthPress_L',
+  'mouthPress_R',
+];
+
+type ProceduralLipGeometryBundle = {
+  geometry: THREE.BufferGeometry;
+  basePositions: Float32Array;
+  expressionDeltas: Record<LipExpressionName, Float32Array>;
+};
 
 function createLipPoint(t: number, row: number, identity: ProceduralHeadIdentity) {
   const lipWidth = lerp(0.32, 0.48, identity.faceWidth);
@@ -32,7 +52,7 @@ function createLipPoint(t: number, row: number, identity: ProceduralHeadIdentity
   return new THREE.Vector3(x, y, z);
 }
 
-export function createProceduralLipGeometry(identity: ProceduralHeadIdentity, quality: ProceduralHeadQuality) {
+export function createProceduralLipGeometry(identity: ProceduralHeadIdentity, quality: ProceduralHeadQuality): ProceduralLipGeometryBundle {
   const config = PROCEDURAL_QUALITY_CONFIG[quality];
   const segments = Math.max(48, Math.round(config.radialSegments * 0.75));
   const rows = quality === 'hero' ? 7 : quality === 'balanced' ? 5 : 4;
@@ -64,18 +84,18 @@ export function createProceduralLipGeometry(identity: ProceduralHeadIdentity, qu
     }
   }
 
+  const basePositions = Float32Array.from(positions);
   const geometry = new THREE.BufferGeometry();
-  geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geometry.setAttribute('position', new THREE.BufferAttribute(basePositions.slice(), 3));
   geometry.setAttribute('normal', new THREE.Float32BufferAttribute(normals, 3));
   geometry.setAttribute('uv', new THREE.Float32BufferAttribute(uvs, 2));
   geometry.setIndex(indices);
   geometry.computeVertexNormals();
   geometry.computeBoundingSphere();
-  geometry.morphTargetsRelative = true;
 
   const base = geometry.getAttribute('position') as THREE.BufferAttribute;
-  const morphNames = ['jawOpen', 'mouthSmile_L', 'mouthSmile_R', 'mouthFunnel', 'mouthPucker', 'mouthPress_L', 'mouthPress_R'];
-  geometry.morphAttributes.position = morphNames.map((name) => {
+  const expressionDeltas = {} as Record<LipExpressionName, Float32Array>;
+  for (const name of LIP_EXPRESSION_NAMES) {
     const deltas = new Float32Array(base.count * 3);
     const point = new THREE.Vector3();
     for (let i = 0; i < base.count; i += 1) {
@@ -110,12 +130,38 @@ export function createProceduralLipGeometry(identity: ProceduralHeadIdentity, qu
       deltas[i * 3 + 1] = delta.y;
       deltas[i * 3 + 2] = delta.z;
     }
-    const attr = new THREE.BufferAttribute(deltas, 3);
-    attr.name = name;
-    return attr;
-  });
+    expressionDeltas[name] = deltas;
+  }
 
-  return geometry;
+  return { geometry, basePositions, expressionDeltas };
+}
+
+function applyProceduralLipExpressions(
+  geometry: THREE.BufferGeometry,
+  basePositions: Float32Array,
+  expressionDeltas: Record<LipExpressionName, Float32Array>,
+  expressions: ProceduralExpressionValues,
+  strength: number,
+) {
+  const position = geometry.getAttribute('position') as THREE.BufferAttribute;
+  const target = position.array as Float32Array;
+  target.set(basePositions);
+
+  for (const name of LIP_EXPRESSION_NAMES) {
+    const influence = clamp((expressions[name as ProceduralExpressionName] ?? 0) * strength);
+    if (influence <= 0) continue;
+
+    const delta = expressionDeltas[name];
+    for (let i = 0; i < target.length; i += 1) {
+      target[i] += delta[i] * influence;
+    }
+  }
+
+  position.needsUpdate = true;
+  geometry.computeVertexNormals();
+  const normal = geometry.getAttribute('normal') as THREE.BufferAttribute | undefined;
+  if (normal) normal.needsUpdate = true;
+  geometry.computeBoundingSphere();
 }
 
 function Tooth({
@@ -156,23 +202,25 @@ export function ProceduralMouthSystem({
 }) {
   const lipsRef = useRef<THREE.Mesh>(null);
   const lowerMouthRef = useRef<THREE.Group>(null);
-  const lipGeometry = useMemo(() => createProceduralLipGeometry(identity, quality), [identity, quality]);
+  const lipBundle = useMemo(() => createProceduralLipGeometry(identity, quality), [identity, quality]);
+  const invalidate = useThree((state) => state.invalidate);
   const jawOpen = clamp((expressions.jawOpen ?? 0) * strength);
 
-  useEffect(() => () => lipGeometry.dispose(), [lipGeometry]);
+  useEffect(() => () => lipBundle.geometry.dispose(), [lipBundle]);
 
   useEffect(() => {
-    setMorphInfluences(lipsRef.current, expressions, strength);
+    applyProceduralLipExpressions(lipBundle.geometry, lipBundle.basePositions, lipBundle.expressionDeltas, expressions, strength);
     if (lowerMouthRef.current) {
       lowerMouthRef.current.position.y = -jawOpen * 0.105;
       lowerMouthRef.current.position.z = -jawOpen * 0.026;
       lowerMouthRef.current.rotation.x = jawOpen * -0.08;
     }
-  }, [expressions, jawOpen, strength]);
+    invalidate();
+  }, [expressions, invalidate, jawOpen, lipBundle, strength]);
 
   return (
     <group>
-      <mesh ref={lipsRef} geometry={lipGeometry}>
+      <mesh ref={lipsRef} geometry={lipBundle.geometry}>
         <ProceduralLipMaterial mode={mode} />
       </mesh>
 

--- a/src/features/procedural-head/random.ts
+++ b/src/features/procedural-head/random.ts
@@ -1,0 +1,80 @@
+export function clamp(value: number, min = 0, max = 1) {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function lerp(a: number, b: number, t: number) {
+  return a + (b - a) * t;
+}
+
+export function smoothstep(edge0: number, edge1: number, value: number) {
+  const t = clamp((value - edge0) / (edge1 - edge0));
+  return t * t * (3 - 2 * t);
+}
+
+export function hashString(value: string) {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+export function mulberry32(seed: number) {
+  let state = seed >>> 0;
+  return () => {
+    state += 0x6d2b79f5;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function latticeNoise(ix: number, iy: number, seed: number) {
+  let h = seed ^ Math.imul(ix, 374761393) ^ Math.imul(iy, 668265263);
+  h = Math.imul(h ^ (h >>> 13), 1274126177);
+  return ((h ^ (h >>> 16)) >>> 0) / 4294967295;
+}
+
+export function valueNoise2D(x: number, y: number, seed: number) {
+  const ix = Math.floor(x);
+  const iy = Math.floor(y);
+  const fx = x - ix;
+  const fy = y - iy;
+  const sx = fx * fx * (3 - 2 * fx);
+  const sy = fy * fy * (3 - 2 * fy);
+
+  const a = latticeNoise(ix, iy, seed);
+  const b = latticeNoise(ix + 1, iy, seed);
+  const c = latticeNoise(ix, iy + 1, seed);
+  const d = latticeNoise(ix + 1, iy + 1, seed);
+
+  return lerp(lerp(a, b, sx), lerp(c, d, sx), sy);
+}
+
+export function fbm2D(x: number, y: number, seed: number, octaves = 4) {
+  let value = 0;
+  let amplitude = 0.5;
+  let frequency = 1;
+  let normalization = 0;
+
+  for (let i = 0; i < octaves; i += 1) {
+    value += valueNoise2D(x * frequency, y * frequency, seed + i * 1013) * amplitude;
+    normalization += amplitude;
+    amplitude *= 0.5;
+    frequency *= 2.03;
+  }
+
+  return value / Math.max(normalization, 0.0001);
+}
+
+export function gaussian2D(x: number, y: number, cx: number, cy: number, sx: number, sy: number) {
+  const dx = (x - cx) / sx;
+  const dy = (y - cy) / sy;
+  return Math.exp(-(dx * dx + dy * dy));
+}
+
+export function colorToCss(r: number, g: number, b: number) {
+  return `rgb(${Math.round(clamp(r, 0, 255))}, ${Math.round(clamp(g, 0, 255))}, ${Math.round(clamp(b, 0, 255))})`;
+}

--- a/src/features/procedural-head/scene.tsx
+++ b/src/features/procedural-head/scene.tsx
@@ -13,19 +13,12 @@ import type {
   ProceduralHeadStats,
 } from './types';
 import { PROCEDURAL_QUALITY_CONFIG } from './types';
-import { createProceduralHeadGeometry } from './geometry';
+import { applyProceduralHeadExpressions, createProceduralHeadGeometry } from './geometry';
 import { createProceduralSkinTexturePack } from './maps';
 import { ProceduralBeautyMaterial, ProceduralEyeMaterials } from './materials';
 import { ProceduralMouthSystem } from './mouthSystem';
 
 export type ProceduralHeadRendererMode = 'webgpu' | 'webgl';
-
-function setMorphInfluences(mesh: THREE.Mesh | null, expressions: ProceduralExpressionValues, strength: number) {
-  if (!mesh?.morphTargetDictionary || !mesh.morphTargetInfluences) return;
-  for (const [name, index] of Object.entries(mesh.morphTargetDictionary)) {
-    mesh.morphTargetInfluences[index] = Math.min(1, Math.max(0, (expressions[name as keyof ProceduralExpressionValues] ?? 0) * strength));
-  }
-}
 
 function SceneGrade() {
   const { gl, scene } = useThree();
@@ -99,6 +92,7 @@ function ProceduralHeadRig({
   strength: number;
 }) {
   const headRef = useRef<THREE.Mesh>(null);
+  const invalidate = useThree((state) => state.invalidate);
   const bundle = useMemo(() => createProceduralHeadGeometry(identity, quality), [identity, quality]);
   const textures = useMemo(() => createProceduralSkinTexturePack(identity, quality), [identity, quality]);
 
@@ -111,15 +105,15 @@ function ProceduralHeadRig({
   }, [textures]);
 
   useEffect(() => {
-    headRef.current?.updateMorphTargets();
-    setMorphInfluences(headRef.current, expressions, strength);
-  }, [bundle, expressions, strength]);
+    applyProceduralHeadExpressions(bundle.geometry, bundle.basePositions, bundle.expressionDeltas, expressions, strength);
+    invalidate();
+  }, [bundle, expressions, invalidate, strength]);
 
   useEffect(() => {
     onStats?.({
       vertices: bundle.geometry.getAttribute('position').count,
       triangles: (bundle.geometry.index?.count ?? 0) / 3,
-      morphTargets: bundle.geometry.morphAttributes.position?.length ?? 0,
+      morphTargets: Object.keys(bundle.expressionDeltas).length,
       mapResolution: textures.resolution,
     });
   }, [bundle, onStats, textures.resolution]);
@@ -172,6 +166,7 @@ export function ProceduralHeadCanvas({
   strength: number;
 }) {
   const config = PROCEDURAL_QUALITY_CONFIG[quality];
+  const eventSource = typeof document === 'undefined' ? undefined : document.body;
   const gl = useMemo(() => {
     if (rendererMode === 'webgl') {
       return {
@@ -197,31 +192,35 @@ export function ProceduralHeadCanvas({
         forceWebGL: false,
       } as ConstructorParameters<typeof THREE_WEBGPU.WebGPURenderer>[0]);
       await renderer.init();
+      (renderer as THREE_WEBGPU.WebGPURenderer & { domElement: HTMLCanvasElement }).domElement = canvas;
       return renderer;
     }) as any;
   }, [onWebGPUFailure, quality, rendererMode]);
 
   return (
-    <Canvas
-      frameloop="demand"
-      camera={{ position: [0, 0.02, 4.3], fov: 31 }}
-      dpr={config.dpr}
-      gl={gl}
-    >
-      {showStats && <Stats />}
-      <AdaptiveDpr />
-      <SceneGrade />
-      <StudioLights />
-      <CubemapEnvironment variant="studio" background={false} />
-      <ProceduralHeadRig
-        expressions={expressions}
-        identity={identity}
-        materialMode={materialMode}
-        onStats={onStats}
-        quality={quality}
-        strength={strength}
-      />
-      <OrbitControls makeDefault enablePan={false} minDistance={2.8} maxDistance={7.2} target={[0, -0.02, -0.45]} />
-    </Canvas>
+    <div className="h-full w-full">
+      <Canvas
+        frameloop="demand"
+        camera={{ position: [0, 0.02, 4.3], fov: 31 }}
+        dpr={config.dpr}
+        eventSource={eventSource}
+        gl={gl}
+      >
+        {showStats && <Stats />}
+        <AdaptiveDpr />
+        <SceneGrade />
+        <StudioLights />
+        <CubemapEnvironment variant="studio" background={false} />
+        <ProceduralHeadRig
+          expressions={expressions}
+          identity={identity}
+          materialMode={materialMode}
+          onStats={onStats}
+          quality={quality}
+          strength={strength}
+        />
+        <OrbitControls makeDefault enablePan={false} minDistance={2.8} maxDistance={7.2} target={[0, -0.02, -0.45]} />
+      </Canvas>
+    </div>
   );
 }

--- a/src/features/procedural-head/scene.tsx
+++ b/src/features/procedural-head/scene.tsx
@@ -1,0 +1,190 @@
+import { OrbitControls, Stats } from '@react-three/drei';
+import { Canvas, useThree } from '@react-three/fiber';
+import { useEffect, useMemo, useRef } from 'react';
+import * as THREE from 'three';
+import CubemapEnvironment from '../../components/CubemapEnvironment';
+import type {
+  ProceduralExpressionValues,
+  ProceduralHeadIdentity,
+  ProceduralHeadMaterialMode,
+  ProceduralHeadQuality,
+  ProceduralHeadStats,
+} from './types';
+import { PROCEDURAL_QUALITY_CONFIG } from './types';
+import { createProceduralHeadGeometry } from './geometry';
+import { createProceduralSkinTexturePack } from './maps';
+import { ProceduralBeautyMaterial, ProceduralEyeMaterials } from './materials';
+import { ProceduralMouthSystem } from './mouthSystem';
+
+function setMorphInfluences(mesh: THREE.Mesh | null, expressions: ProceduralExpressionValues, strength: number) {
+  if (!mesh?.morphTargetDictionary || !mesh.morphTargetInfluences) return;
+  for (const [name, index] of Object.entries(mesh.morphTargetDictionary)) {
+    mesh.morphTargetInfluences[index] = Math.min(1, Math.max(0, (expressions[name as keyof ProceduralExpressionValues] ?? 0) * strength));
+  }
+}
+
+function SceneGrade() {
+  const { gl, scene } = useThree();
+  useEffect(() => {
+    gl.outputColorSpace = THREE.SRGBColorSpace;
+    gl.toneMapping = THREE.AgXToneMapping;
+    gl.toneMappingExposure = 1.08;
+    scene.background = new THREE.Color('#151716');
+    scene.environmentIntensity = 1.1;
+  }, [gl, scene]);
+  return null;
+}
+
+function StudioLights() {
+  return (
+    <>
+      <spotLight position={[3.2, 4.1, 4.8]} angle={0.36} penumbra={0.72} intensity={7.2} color="#fff4e7" />
+      <spotLight position={[-2.8, 2.3, 3.2]} angle={0.5} penumbra={0.82} intensity={2.7} color="#bfd8ff" />
+      <pointLight position={[0, -1.8, 2.2]} intensity={1.2} color="#ffc7a8" />
+      <directionalLight position={[0.4, 2.8, -3]} intensity={1.8} color="#ffe2cc" />
+      <ambientLight intensity={0.18} />
+      <hemisphereLight args={['#edf3ff', '#302721', 0.35]} />
+    </>
+  );
+}
+function Eye({
+  mode,
+  position,
+  scale,
+}: {
+  mode: ProceduralHeadMaterialMode;
+  position: [number, number, number];
+  scale: number;
+}) {
+  const materials = ProceduralEyeMaterials({ mode });
+  return (
+    <group position={position} scale={scale}>
+      <mesh scale={[1.06, 0.72, 0.9]}>
+        <sphereGeometry args={[0.11, 32, 16]} />
+        {materials.sclera}
+      </mesh>
+      <mesh position={[0, 0, 0.092]} rotation={[0, 0, 0]}>
+        <circleGeometry args={[0.043, 36]} />
+        {materials.iris}
+      </mesh>
+      <mesh position={[0, 0, 0.094]}>
+        <circleGeometry args={[0.018, 28]} />
+        {materials.pupil}
+      </mesh>
+      <mesh scale={[1.08, 0.74, 0.92]}>
+        <sphereGeometry args={[0.113, 32, 16]} />
+        {materials.cornea}
+      </mesh>
+    </group>
+  );
+}
+
+function ProceduralHeadRig({
+  expressions,
+  identity,
+  materialMode,
+  onStats,
+  quality,
+  strength,
+}: {
+  expressions: ProceduralExpressionValues;
+  identity: ProceduralHeadIdentity;
+  materialMode: ProceduralHeadMaterialMode;
+  onStats?: (stats: ProceduralHeadStats) => void;
+  quality: ProceduralHeadQuality;
+  strength: number;
+}) {
+  const headRef = useRef<THREE.Mesh>(null);
+  const bundle = useMemo(() => createProceduralHeadGeometry(identity, quality), [identity, quality]);
+  const textures = useMemo(() => createProceduralSkinTexturePack(identity, quality), [identity, quality]);
+
+  useEffect(() => () => {
+    bundle.geometry.dispose();
+  }, [bundle]);
+
+  useEffect(() => () => {
+    textures.dispose();
+  }, [textures]);
+
+  useEffect(() => {
+    headRef.current?.updateMorphTargets();
+    setMorphInfluences(headRef.current, expressions, strength);
+  }, [bundle, expressions, strength]);
+
+  useEffect(() => {
+    onStats?.({
+      vertices: bundle.geometry.getAttribute('position').count,
+      triangles: (bundle.geometry.index?.count ?? 0) / 3,
+      morphTargets: bundle.geometry.morphAttributes.position?.length ?? 0,
+      mapResolution: textures.resolution,
+    });
+  }, [bundle, onStats, textures.resolution]);
+
+  const eyeScale = 0.88 + identity.eyeScale * 0.28;
+  const eyeY = 0.245;
+  const eyeZ = 0.545;
+
+  return (
+    <group position={[0, -0.04, -0.4]} rotation={[0.02, 0, 0]} scale={1.45}>
+      <mesh ref={headRef} geometry={bundle.geometry}>
+        <ProceduralBeautyMaterial mode={materialMode} quality={quality} textures={textures} />
+      </mesh>
+      <Eye mode={materialMode} position={[bundle.anchors.leftEye.x, eyeY, eyeZ]} scale={eyeScale} />
+      <Eye mode={materialMode} position={[bundle.anchors.rightEye.x, eyeY, eyeZ]} scale={eyeScale} />
+      <ProceduralMouthSystem
+        expressions={expressions}
+        identity={identity}
+        mode={materialMode}
+        quality={quality}
+        strength={strength}
+      />
+      <mesh position={[0, -1.18, -0.06]} scale={[0.76, 0.82, 0.58]}>
+        <sphereGeometry args={[0.42, 48, 20]} />
+        <meshPhysicalMaterial color="#6f5549" roughness={0.62} metalness={0} envMapIntensity={0.28} wireframe={materialMode === 'topology'} />
+      </mesh>
+    </group>
+  );
+}
+
+export function ProceduralHeadCanvas({
+  expressions,
+  identity,
+  materialMode,
+  onStats,
+  quality,
+  showStats,
+  strength,
+}: {
+  expressions: ProceduralExpressionValues;
+  identity: ProceduralHeadIdentity;
+  materialMode: ProceduralHeadMaterialMode;
+  onStats?: (stats: ProceduralHeadStats) => void;
+  quality: ProceduralHeadQuality;
+  showStats: boolean;
+  strength: number;
+}) {
+  const config = PROCEDURAL_QUALITY_CONFIG[quality];
+
+  return (
+    <Canvas
+      frameloop="demand"
+      camera={{ position: [0, 0.02, 4.3], fov: 31 }}
+      dpr={config.dpr}
+      gl={{ antialias: quality !== 'fast', powerPreference: 'high-performance' }}
+    >
+      {showStats && <Stats />}
+      <SceneGrade />
+      <StudioLights />
+      <CubemapEnvironment variant="studio" background={false} />
+      <ProceduralHeadRig
+        expressions={expressions}
+        identity={identity}
+        materialMode={materialMode}
+        onStats={onStats}
+        quality={quality}
+        strength={strength}
+      />
+      <OrbitControls makeDefault enablePan={false} minDistance={2.8} maxDistance={7.2} target={[0, -0.02, -0.45]} />
+    </Canvas>
+  );
+}

--- a/src/features/procedural-head/scene.tsx
+++ b/src/features/procedural-head/scene.tsx
@@ -1,8 +1,10 @@
-import { OrbitControls, Stats } from '@react-three/drei';
+import { AdaptiveDpr, OrbitControls, Stats } from '@react-three/drei';
 import { Canvas, useThree } from '@react-three/fiber';
 import { useEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
+import * as THREE_WEBGPU from 'three/webgpu';
 import CubemapEnvironment from '../../components/CubemapEnvironment';
+import { probeWebGPUSession, type WebGPUSessionProbeResult } from '../../utils/webgpuSession';
 import type {
   ProceduralExpressionValues,
   ProceduralHeadIdentity,
@@ -15,6 +17,8 @@ import { createProceduralHeadGeometry } from './geometry';
 import { createProceduralSkinTexturePack } from './maps';
 import { ProceduralBeautyMaterial, ProceduralEyeMaterials } from './materials';
 import { ProceduralMouthSystem } from './mouthSystem';
+
+export type ProceduralHeadRendererMode = 'webgpu' | 'webgl';
 
 function setMorphInfluences(mesh: THREE.Mesh | null, expressions: ProceduralExpressionValues, strength: number) {
   if (!mesh?.morphTargetDictionary || !mesh.morphTargetInfluences) return;
@@ -152,6 +156,8 @@ export function ProceduralHeadCanvas({
   materialMode,
   onStats,
   quality,
+  rendererMode,
+  onWebGPUFailure,
   showStats,
   strength,
 }: {
@@ -159,20 +165,51 @@ export function ProceduralHeadCanvas({
   identity: ProceduralHeadIdentity;
   materialMode: ProceduralHeadMaterialMode;
   onStats?: (stats: ProceduralHeadStats) => void;
+  onWebGPUFailure?: (result: WebGPUSessionProbeResult) => void;
   quality: ProceduralHeadQuality;
+  rendererMode: ProceduralHeadRendererMode;
   showStats: boolean;
   strength: number;
 }) {
   const config = PROCEDURAL_QUALITY_CONFIG[quality];
+  const gl = useMemo(() => {
+    if (rendererMode === 'webgl') {
+      return {
+        antialias: quality !== 'fast',
+        powerPreference: 'high-performance' as const,
+        alpha: false,
+        stencil: false,
+      };
+    }
+
+    return (async (defaults: Record<string, unknown>) => {
+      const canvas = defaults.canvas as HTMLCanvasElement;
+      const result = await probeWebGPUSession({ canvas });
+      if (!result.ok) {
+        onWebGPUFailure?.(result);
+        throw new Error(result.message);
+      }
+
+      const renderer = new THREE_WEBGPU.WebGPURenderer({
+        canvas,
+        antialias: quality !== 'fast',
+        alpha: false,
+        forceWebGL: false,
+      } as ConstructorParameters<typeof THREE_WEBGPU.WebGPURenderer>[0]);
+      await renderer.init();
+      return renderer;
+    }) as any;
+  }, [onWebGPUFailure, quality, rendererMode]);
 
   return (
     <Canvas
       frameloop="demand"
       camera={{ position: [0, 0.02, 4.3], fov: 31 }}
       dpr={config.dpr}
-      gl={{ antialias: quality !== 'fast', powerPreference: 'high-performance' }}
+      gl={gl}
     >
       {showStats && <Stats />}
+      <AdaptiveDpr />
       <SceneGrade />
       <StudioLights />
       <CubemapEnvironment variant="studio" background={false} />

--- a/src/features/procedural-head/types.ts
+++ b/src/features/procedural-head/types.ts
@@ -1,0 +1,202 @@
+export type ProceduralHeadQuality = 'fast' | 'balanced' | 'hero';
+
+export type ProceduralHeadMaterialMode = 'beauty' | 'maps' | 'topology';
+
+export type ProceduralExpressionPreset =
+  | 'neutral'
+  | 'softSmile'
+  | 'jawOpen'
+  | 'pucker'
+  | 'squint'
+  | 'browRaise'
+  | 'stressTest';
+
+export type ProceduralExpressionName =
+  | 'browInnerUp'
+  | 'browOuterUp_L'
+  | 'browOuterUp_R'
+  | 'eyeBlink_L'
+  | 'eyeBlink_R'
+  | 'eyeSquint_L'
+  | 'eyeSquint_R'
+  | 'cheekSquint_L'
+  | 'cheekSquint_R'
+  | 'jawOpen'
+  | 'mouthSmile_L'
+  | 'mouthSmile_R'
+  | 'mouthFunnel'
+  | 'mouthPucker'
+  | 'mouthPress_L'
+  | 'mouthPress_R'
+  | 'noseSneer_L'
+  | 'noseSneer_R';
+
+export type ProceduralExpressionValues = Partial<Record<ProceduralExpressionName, number>>;
+
+export type ProceduralHeadIdentity = {
+  seed: string;
+  faceWidth: number;
+  skullHeight: number;
+  jawWidth: number;
+  cheekbone: number;
+  browRidge: number;
+  noseProjection: number;
+  noseWidth: number;
+  lipFullness: number;
+  eyeSpacing: number;
+  eyeScale: number;
+  melanin: number;
+  hemoglobin: number;
+  poreScale: number;
+  oiliness: number;
+  age: number;
+};
+
+export type ProceduralHeadStats = {
+  vertices: number;
+  triangles: number;
+  morphTargets: number;
+  mapResolution: number;
+};
+
+export const PROCEDURAL_EXPRESSION_NAMES: ProceduralExpressionName[] = [
+  'browInnerUp',
+  'browOuterUp_L',
+  'browOuterUp_R',
+  'eyeBlink_L',
+  'eyeBlink_R',
+  'eyeSquint_L',
+  'eyeSquint_R',
+  'cheekSquint_L',
+  'cheekSquint_R',
+  'jawOpen',
+  'mouthSmile_L',
+  'mouthSmile_R',
+  'mouthFunnel',
+  'mouthPucker',
+  'mouthPress_L',
+  'mouthPress_R',
+  'noseSneer_L',
+  'noseSneer_R',
+];
+
+export const DEFAULT_PROCEDURAL_IDENTITY: ProceduralHeadIdentity = {
+  seed: 'studio-01',
+  faceWidth: 0.48,
+  skullHeight: 0.56,
+  jawWidth: 0.38,
+  cheekbone: 0.58,
+  browRidge: 0.44,
+  noseProjection: 0.52,
+  noseWidth: 0.42,
+  lipFullness: 0.54,
+  eyeSpacing: 0.5,
+  eyeScale: 0.48,
+  melanin: 0.42,
+  hemoglobin: 0.46,
+  poreScale: 0.62,
+  oiliness: 0.42,
+  age: 0.34,
+};
+
+export const PROCEDURAL_QUALITY_CONFIG: Record<ProceduralHeadQuality, {
+  label: string;
+  radialSegments: number;
+  verticalSegments: number;
+  mapResolution: number;
+  dpr: [number, number];
+}> = {
+  fast: {
+    label: 'Fast',
+    radialSegments: 56,
+    verticalSegments: 48,
+    mapResolution: 384,
+    dpr: [1, 1],
+  },
+  balanced: {
+    label: 'Balanced',
+    radialSegments: 80,
+    verticalSegments: 64,
+    mapResolution: 640,
+    dpr: [1, 1.25],
+  },
+  hero: {
+    label: 'Hero',
+    radialSegments: 112,
+    verticalSegments: 88,
+    mapResolution: 1024,
+    dpr: [1, 1.5],
+  },
+};
+export const PROCEDURAL_EXPRESSION_PRESETS: Record<ProceduralExpressionPreset, {
+  label: string;
+  description: string;
+  values: ProceduralExpressionValues;
+}> = {
+  neutral: {
+    label: 'Neutral',
+    description: 'Closed-mouth neutral pose for material and topology inspection.',
+    values: {},
+  },
+  softSmile: {
+    label: 'Soft Smile',
+    description: 'Constrained smile that tests cheek, lip, and dental occlusion.',
+    values: {
+      mouthSmile_L: 0.62,
+      mouthSmile_R: 0.62,
+      cheekSquint_L: 0.28,
+      cheekSquint_R: 0.28,
+    },
+  },
+  jawOpen: {
+    label: 'Jaw Open',
+    description: 'Oral-system stress pose for teeth, gums, tongue, and mouth shadow.',
+    values: {
+      jawOpen: 0.78,
+      mouthFunnel: 0.12,
+    },
+  },
+  pucker: {
+    label: 'Pucker',
+    description: 'Forward lip motion with narrowed corners.',
+    values: {
+      mouthPucker: 0.72,
+      mouthFunnel: 0.46,
+      mouthPress_L: 0.2,
+      mouthPress_R: 0.2,
+    },
+  },
+  squint: {
+    label: 'Squint',
+    description: 'Eye and cheek compression without invoking webcam tracking.',
+    values: {
+      eyeSquint_L: 0.62,
+      eyeSquint_R: 0.62,
+      cheekSquint_L: 0.46,
+      cheekSquint_R: 0.46,
+    },
+  },
+  browRaise: {
+    label: 'Brow Raise',
+    description: 'Upper-face expression test for procedural wrinkle masks.',
+    values: {
+      browInnerUp: 0.7,
+      browOuterUp_L: 0.48,
+      browOuterUp_R: 0.48,
+    },
+  },
+  stressTest: {
+    label: 'Stress Test',
+    description: 'Combined expression to reveal bad topology or oral intersections.',
+    values: {
+      browInnerUp: 0.34,
+      eyeSquint_L: 0.36,
+      eyeSquint_R: 0.36,
+      jawOpen: 0.48,
+      mouthSmile_L: 0.52,
+      mouthSmile_R: 0.52,
+      noseSneer_L: 0.28,
+      noseSneer_R: 0.28,
+    },
+  },
+};

--- a/src/routes/ProceduralHeadRoute.tsx
+++ b/src/routes/ProceduralHeadRoute.tsx
@@ -100,7 +100,8 @@ export default function ProceduralHeadRoute() {
 
   const expressions = useMemo(() => PROCEDURAL_EXPRESSION_PRESETS[preset].values, [preset]);
   const activePreset = PROCEDURAL_EXPRESSION_PRESETS[preset];
-  const rendererMode: ProceduralHeadRendererMode = rendererPreference === 'webgpu' && webgpuProbe?.ok ? 'webgpu' : 'webgl';
+  const rendererMode: ProceduralHeadRendererMode | null =
+    rendererPreference === 'webgpu' ? (webgpuProbe ? (webgpuProbe.ok ? 'webgpu' : 'webgl') : null) : 'webgl';
   const handleWebGPUFailure = useCallback((result: WebGPUSessionProbeResult) => {
     setWebgpuProbe(result);
     setRendererPreference('webgl');
@@ -118,21 +119,29 @@ export default function ProceduralHeadRoute() {
 
   return (
     <RouteShell>
-      <CanvasErrorBoundary key={rendererMode}>
-        <div className="absolute inset-0">
-          <ProceduralHeadCanvas
-            expressions={expressions}
-            identity={deferredIdentity}
-            materialMode={materialMode}
-            onStats={setStats}
-            onWebGPUFailure={handleWebGPUFailure}
-            quality={quality}
-            rendererMode={rendererMode}
-            showStats={showStats}
-            strength={strength}
-          />
+      {rendererMode ? (
+        <CanvasErrorBoundary key={rendererMode}>
+          <div className="absolute inset-0">
+            <ProceduralHeadCanvas
+              expressions={expressions}
+              identity={deferredIdentity}
+              materialMode={materialMode}
+              onStats={setStats}
+              onWebGPUFailure={handleWebGPUFailure}
+              quality={quality}
+              rendererMode={rendererMode}
+              showStats={showStats}
+              strength={strength}
+            />
+          </div>
+        </CanvasErrorBoundary>
+      ) : (
+        <div className="absolute inset-0 grid place-items-center">
+          <div className="rounded-[2rem] border border-sky-200/20 bg-black/60 px-6 py-5 text-sm text-sky-50 shadow-2xl backdrop-blur">
+            Checking WebGPU session before creating the renderer.
+          </div>
         </div>
-      </CanvasErrorBoundary>
+      )}
 
       <section className="absolute bottom-4 left-4 top-20 z-20 flex w-[min(360px,calc(100vw-2rem))] flex-col gap-3 overflow-hidden rounded-[2rem] border border-white/10 bg-black/52 p-4 text-sm shadow-2xl backdrop-blur-2xl">
         <div>
@@ -174,9 +183,9 @@ export default function ProceduralHeadRoute() {
         </div>
 
         <p className="rounded-2xl border border-white/8 bg-white/5 px-3 py-2 text-[11px] leading-5 text-stone-400">
-          Renderer: <span className="font-semibold uppercase text-stone-200">{rendererMode}</span>
+          Renderer: <span className="font-semibold uppercase text-stone-200">{rendererMode ?? 'checking'}</span>
           {rendererPreference === 'webgpu' && webgpuProbe?.ok === false ? ` fallback. ${webgpuProbe.message}` : ''}
-          {rendererPreference === 'webgpu' && !webgpuProbe ? ' preflight running; WebGL fallback is active until the adapter is verified.' : ''}
+          {rendererPreference === 'webgpu' && !webgpuProbe ? ' preflight running; renderer creation is paused until the adapter is verified.' : ''}
         </p>
 
         <div className="grid grid-cols-3 gap-1 rounded-2xl bg-white/5 p-1 text-xs">

--- a/src/routes/ProceduralHeadRoute.tsx
+++ b/src/routes/ProceduralHeadRoute.tsx
@@ -1,0 +1,242 @@
+import React, { startTransition, useDeferredValue, useMemo, useState } from 'react';
+import AppNav from '../components/AppNav';
+import CanvasErrorBoundary from '../components/CanvasErrorBoundary';
+import { ProceduralHeadCanvas } from '../features/procedural-head/scene';
+import type {
+  ProceduralExpressionPreset,
+  ProceduralHeadIdentity,
+  ProceduralHeadMaterialMode,
+  ProceduralHeadQuality,
+  ProceduralHeadStats,
+} from '../features/procedural-head/types';
+import {
+  DEFAULT_PROCEDURAL_IDENTITY,
+  PROCEDURAL_EXPRESSION_PRESETS,
+  PROCEDURAL_QUALITY_CONFIG,
+} from '../features/procedural-head/types';
+
+const IDENTITY_CONTROLS: Array<{
+  key: keyof Omit<ProceduralHeadIdentity, 'seed'>;
+  label: string;
+}> = [
+  { key: 'faceWidth', label: 'Face width' },
+  { key: 'skullHeight', label: 'Skull height' },
+  { key: 'jawWidth', label: 'Jaw width' },
+  { key: 'cheekbone', label: 'Cheekbone' },
+  { key: 'browRidge', label: 'Brow ridge' },
+  { key: 'noseProjection', label: 'Nose projection' },
+  { key: 'noseWidth', label: 'Nose width' },
+  { key: 'lipFullness', label: 'Lip fullness' },
+  { key: 'eyeSpacing', label: 'Eye spacing' },
+  { key: 'eyeScale', label: 'Eye scale' },
+  { key: 'melanin', label: 'Melanin' },
+  { key: 'hemoglobin', label: 'Hemoglobin' },
+  { key: 'poreScale', label: 'Pore scale' },
+  { key: 'oiliness', label: 'Oiliness' },
+  { key: 'age', label: 'Age detail' },
+];
+
+function Slider({
+  identity,
+  identityKey,
+  label,
+  setIdentity,
+}: {
+  identity: ProceduralHeadIdentity;
+  identityKey: keyof Omit<ProceduralHeadIdentity, 'seed'>;
+  label: string;
+  setIdentity: React.Dispatch<React.SetStateAction<ProceduralHeadIdentity>>;
+}) {
+  return (
+    <label className="grid gap-1 text-[11px] text-stone-300">
+      <span className="flex items-center justify-between">
+        <span>{label}</span>
+        <span className="font-mono text-stone-500">{identity[identityKey].toFixed(2)}</span>
+      </span>
+      <input
+        type="range"
+        min={0}
+        max={1}
+        step={0.01}
+        value={identity[identityKey]}
+        onChange={(event) => {
+          const value = Number(event.target.value);
+          startTransition(() => {
+            setIdentity((current) => ({ ...current, [identityKey]: value }));
+          });
+        }}
+        className="accent-lime-300"
+      />
+    </label>
+  );
+}
+function RouteShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative h-screen w-full overflow-hidden bg-[#151716] text-stone-100">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_28%_18%,rgba(203,255,183,0.16),transparent_32%),radial-gradient(circle_at_78%_12%,rgba(255,214,170,0.12),transparent_28%),linear-gradient(135deg,rgba(255,255,255,0.03),transparent_42%)]" />
+      <div className="absolute left-0 right-0 top-0 z-30 flex items-center justify-between px-4 py-3">
+        <AppNav />
+        <div className="pointer-events-none hidden rounded-full border border-lime-200/15 bg-lime-200/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.22em] text-lime-100/75 md:block">
+          Procedural Generator
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export default function ProceduralHeadRoute() {
+  const [identity, setIdentity] = useState<ProceduralHeadIdentity>(DEFAULT_PROCEDURAL_IDENTITY);
+  const [quality, setQuality] = useState<ProceduralHeadQuality>('balanced');
+  const [materialMode, setMaterialMode] = useState<ProceduralHeadMaterialMode>('beauty');
+  const [preset, setPreset] = useState<ProceduralExpressionPreset>('neutral');
+  const [strength, setStrength] = useState(1);
+  const [showStats, setShowStats] = useState(false);
+  const [stats, setStats] = useState<ProceduralHeadStats | null>(null);
+  const deferredIdentity = useDeferredValue(identity);
+
+  const expressions = useMemo(() => PROCEDURAL_EXPRESSION_PRESETS[preset].values, [preset]);
+  const activePreset = PROCEDURAL_EXPRESSION_PRESETS[preset];
+
+  return (
+    <RouteShell>
+      <CanvasErrorBoundary>
+        <div className="absolute inset-0">
+          <ProceduralHeadCanvas
+            expressions={expressions}
+            identity={deferredIdentity}
+            materialMode={materialMode}
+            onStats={setStats}
+            quality={quality}
+            showStats={showStats}
+            strength={strength}
+          />
+        </div>
+      </CanvasErrorBoundary>
+
+      <section className="absolute bottom-4 left-4 top-20 z-20 flex w-[min(360px,calc(100vw-2rem))] flex-col gap-3 overflow-hidden rounded-[2rem] border border-white/10 bg-black/52 p-4 text-sm shadow-2xl backdrop-blur-2xl">
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-lime-200/75">In-house procedural head</p>
+          <h1 className="mt-2 text-2xl font-semibold tracking-tight text-stone-50">Generated, baked, then rendered</h1>
+          <p className="mt-2 text-xs leading-5 text-stone-400">
+            This lab creates procedural topology, procedural skin maps, separate oral materials, and ARKit-style expression targets without Facecap or photogrammetry.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-3 gap-1 rounded-2xl bg-white/5 p-1 text-xs">
+          {(['beauty', 'maps', 'topology'] as ProceduralHeadMaterialMode[]).map((mode) => (
+            <button
+              key={mode}
+              onClick={() => setMaterialMode(mode)}
+              className={`rounded-xl px-2 py-1.5 capitalize transition ${materialMode === mode ? 'bg-lime-200 text-stone-950' : 'text-stone-300 hover:bg-white/10'}`}
+            >
+              {mode}
+            </button>
+          ))}
+        </div>
+
+        <div className="grid grid-cols-3 gap-1 rounded-2xl bg-white/5 p-1 text-xs">
+          {(Object.keys(PROCEDURAL_QUALITY_CONFIG) as ProceduralHeadQuality[]).map((nextQuality) => (
+            <button
+              key={nextQuality}
+              onClick={() => setQuality(nextQuality)}
+              className={`rounded-xl px-2 py-1.5 transition ${quality === nextQuality ? 'bg-stone-100 text-stone-950' : 'text-stone-300 hover:bg-white/10'}`}
+            >
+              {PROCEDURAL_QUALITY_CONFIG[nextQuality].label}
+            </button>
+          ))}
+        </div>
+
+        <label className="grid gap-1 text-[11px] text-stone-300">
+          <span className="flex items-center justify-between">
+            <span>Seed</span>
+            <span className="font-mono text-stone-500">{identity.seed}</span>
+          </span>
+          <input
+            value={identity.seed}
+            onChange={(event) => {
+              const seed = event.target.value;
+              startTransition(() => setIdentity((current) => ({ ...current, seed })));
+            }}
+            className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 font-mono text-xs text-stone-100 outline-none transition focus:border-lime-200/50"
+          />
+        </label>
+
+        <div className="min-h-0 flex-1 overflow-auto pr-1">
+          <div className="grid gap-2">
+            {IDENTITY_CONTROLS.map((control) => (
+              <Slider
+                key={control.key}
+                identity={identity}
+                identityKey={control.key}
+                label={control.label}
+                setIdentity={setIdentity}
+              />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="absolute bottom-4 right-4 z-20 w-[min(420px,calc(100vw-2rem))] rounded-[2rem] border border-white/10 bg-black/52 p-4 shadow-2xl backdrop-blur-2xl">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-amber-200/75">Expression system</p>
+            <h2 className="mt-1 text-lg font-semibold text-stone-50">{activePreset.label}</h2>
+            <p className="mt-1 text-xs leading-5 text-stone-400">{activePreset.description}</p>
+          </div>
+          <label className="flex items-center gap-2 text-[11px] text-stone-400">
+            <input type="checkbox" checked={showStats} onChange={(event) => setShowStats(event.target.checked)} className="accent-lime-300" />
+            Stats
+          </label>
+        </div>
+
+        <div className="mt-3 grid grid-cols-3 gap-1">
+          {(Object.keys(PROCEDURAL_EXPRESSION_PRESETS) as ProceduralExpressionPreset[]).map((nextPreset) => (
+            <button
+              key={nextPreset}
+              onClick={() => setPreset(nextPreset)}
+              className={`rounded-xl px-2 py-1.5 text-xs transition ${preset === nextPreset ? 'bg-amber-200 text-stone-950' : 'bg-white/5 text-stone-300 hover:bg-white/10'}`}
+            >
+              {PROCEDURAL_EXPRESSION_PRESETS[nextPreset].label}
+            </button>
+          ))}
+        </div>
+
+        <label className="mt-3 grid gap-1 text-[11px] text-stone-300">
+          <span className="flex items-center justify-between">
+            <span>Expression strength</span>
+            <span className="font-mono text-stone-500">{strength.toFixed(2)}</span>
+          </span>
+          <input
+            type="range"
+            min={0}
+            max={1.25}
+            step={0.01}
+            value={strength}
+            onChange={(event) => setStrength(Number(event.target.value))}
+            className="accent-amber-200"
+          />
+        </label>
+
+        <div className="mt-3 grid grid-cols-4 gap-2 text-[10px] uppercase tracking-[0.16em] text-stone-500">
+          <div className="rounded-2xl border border-white/8 bg-white/5 p-2">
+            <span className="block text-stone-300">{stats ? Math.round(stats.vertices).toLocaleString() : '-'}</span>
+            vertices
+          </div>
+          <div className="rounded-2xl border border-white/8 bg-white/5 p-2">
+            <span className="block text-stone-300">{stats ? Math.round(stats.triangles).toLocaleString() : '-'}</span>
+            tris
+          </div>
+          <div className="rounded-2xl border border-white/8 bg-white/5 p-2">
+            <span className="block text-stone-300">{stats?.morphTargets ?? '-'}</span>
+            morphs
+          </div>
+          <div className="rounded-2xl border border-white/8 bg-white/5 p-2">
+            <span className="block text-stone-300">{stats ? `${stats.mapResolution}px` : '-'}</span>
+            maps
+          </div>
+        </div>
+      </section>
+    </RouteShell>
+  );
+}

--- a/src/routes/ProceduralHeadRoute.tsx
+++ b/src/routes/ProceduralHeadRoute.tsx
@@ -1,7 +1,7 @@
-import React, { startTransition, useDeferredValue, useMemo, useState } from 'react';
+import React, { startTransition, useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react';
 import AppNav from '../components/AppNav';
 import CanvasErrorBoundary from '../components/CanvasErrorBoundary';
-import { ProceduralHeadCanvas } from '../features/procedural-head/scene';
+import { ProceduralHeadCanvas, type ProceduralHeadRendererMode } from '../features/procedural-head/scene';
 import type {
   ProceduralExpressionPreset,
   ProceduralHeadIdentity,
@@ -14,6 +14,7 @@ import {
   PROCEDURAL_EXPRESSION_PRESETS,
   PROCEDURAL_QUALITY_CONFIG,
 } from '../features/procedural-head/types';
+import { probeWebGPUSession, type WebGPUSessionProbeResult } from '../utils/webgpuSession';
 
 const IDENTITY_CONTROLS: Array<{
   key: keyof Omit<ProceduralHeadIdentity, 'seed'>;
@@ -90,6 +91,8 @@ export default function ProceduralHeadRoute() {
   const [quality, setQuality] = useState<ProceduralHeadQuality>('balanced');
   const [materialMode, setMaterialMode] = useState<ProceduralHeadMaterialMode>('beauty');
   const [preset, setPreset] = useState<ProceduralExpressionPreset>('neutral');
+  const [rendererPreference, setRendererPreference] = useState<ProceduralHeadRendererMode>('webgpu');
+  const [webgpuProbe, setWebgpuProbe] = useState<WebGPUSessionProbeResult | null>(null);
   const [strength, setStrength] = useState(1);
   const [showStats, setShowStats] = useState(false);
   const [stats, setStats] = useState<ProceduralHeadStats | null>(null);
@@ -97,17 +100,34 @@ export default function ProceduralHeadRoute() {
 
   const expressions = useMemo(() => PROCEDURAL_EXPRESSION_PRESETS[preset].values, [preset]);
   const activePreset = PROCEDURAL_EXPRESSION_PRESETS[preset];
+  const rendererMode: ProceduralHeadRendererMode = rendererPreference === 'webgpu' && webgpuProbe?.ok ? 'webgpu' : 'webgl';
+  const handleWebGPUFailure = useCallback((result: WebGPUSessionProbeResult) => {
+    setWebgpuProbe(result);
+    setRendererPreference('webgl');
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    probeWebGPUSession().then((result) => {
+      if (!cancelled) setWebgpuProbe(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   return (
     <RouteShell>
-      <CanvasErrorBoundary>
+      <CanvasErrorBoundary key={rendererMode}>
         <div className="absolute inset-0">
           <ProceduralHeadCanvas
             expressions={expressions}
             identity={deferredIdentity}
             materialMode={materialMode}
             onStats={setStats}
+            onWebGPUFailure={handleWebGPUFailure}
             quality={quality}
+            rendererMode={rendererMode}
             showStats={showStats}
             strength={strength}
           />
@@ -134,6 +154,30 @@ export default function ProceduralHeadRoute() {
             </button>
           ))}
         </div>
+
+        <div className="grid grid-cols-2 gap-1 rounded-2xl bg-white/5 p-1 text-xs">
+          {(['webgpu', 'webgl'] as ProceduralHeadRendererMode[]).map((mode) => {
+            const disabled = mode === 'webgpu' && webgpuProbe?.ok === false;
+            return (
+              <button
+                key={mode}
+                disabled={disabled}
+                onClick={() => setRendererPreference(mode)}
+                className={`rounded-xl px-2 py-1.5 uppercase transition ${
+                  rendererMode === mode ? 'bg-sky-200 text-stone-950' : disabled ? 'cursor-not-allowed text-stone-600' : 'text-stone-300 hover:bg-white/10'
+                }`}
+              >
+                {mode}
+              </button>
+            );
+          })}
+        </div>
+
+        <p className="rounded-2xl border border-white/8 bg-white/5 px-3 py-2 text-[11px] leading-5 text-stone-400">
+          Renderer: <span className="font-semibold uppercase text-stone-200">{rendererMode}</span>
+          {rendererPreference === 'webgpu' && webgpuProbe?.ok === false ? ` fallback. ${webgpuProbe.message}` : ''}
+          {rendererPreference === 'webgpu' && !webgpuProbe ? ' preflight running; WebGL fallback is active until the adapter is verified.' : ''}
+        </p>
 
         <div className="grid grid-cols-3 gap-1 rounded-2xl bg-white/5 p-1 text-xs">
           {(Object.keys(PROCEDURAL_QUALITY_CONFIG) as ProceduralHeadQuality[]).map((nextQuality) => (

--- a/src/routes/routeConfig.ts
+++ b/src/routes/routeConfig.ts
@@ -1,5 +1,6 @@
 export const APP_NAV_ITEMS = [
   { to: '/', label: 'Main App', surface: 'product' },
+  { to: '/labs/procedural-head', label: 'Procedural Head', surface: 'lab' },
   { to: '/labs/beauty-webgpu', label: 'Beauty WebGPU', surface: 'lab' },
   { to: '/labs/material-parity', label: 'Material Parity', surface: 'lab' },
   { to: '/labs/asset-conditioning', label: 'Asset Conditioning', surface: 'lab' },


### PR DESCRIPTION
## Summary
- Add a new `/labs/procedural-head` route for an in-house procedural head generator.
- Generate deterministic head topology, procedural skin maps, and separate mouth/eye materials without Facecap or photogrammetry.
- Add shot-style controls for identity, expression presets, mouth safety, skin detail, and quality tiers.
- Keep the lab isolated from the main face rig while preserving the existing app routes.

## Validation
- `pnpm lint`
- `pnpm build`
- `Invoke-WebRequest http://127.0.0.1:3003/labs/procedural-head`

## Notes
- This is a procedural foundation for replacing the current placeholder asset, not final human photorealism yet.
- Browser visual inspection is still blocked in this Codex desktop session because the in-app browser Node client requires a newer Node runtime than the configured `C:\nvm4w\nodejs\node.exe`.
- Existing Vite large-chunk warnings remain unrelated to this route.
